### PR TITLE
Implement navigation and role display

### DIFF
--- a/frontend/attendance.html
+++ b/frontend/attendance.html
@@ -12,6 +12,7 @@
         <a href="report.html">Report</a> |
         <a href="dashboard.html">Dashboard</a> |
         <a href="#" id="logout">Logout</a>
+        <span id="user-role" class="role-label"></span>
     </nav>
     <section>
         <button id="clock-in">Clock In</button>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -11,6 +11,7 @@
         <a href="attendance.html">Attendance</a> |
         <a href="report.html">Report</a> |
         <a href="#" id="logout">Logout</a>
+        <span id="user-role" class="role-label"></span>
     </nav>
     <div id="dashboard-data"></div>
     <script src="src/dashboard.js"></script>

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -17,6 +17,7 @@
         </select><br>
         <button type="submit">Create</button>
     </form>
+    <p><a href="login.html">Back to Login</a></p>
     <script src="src/register.js"></script>
 </body>
 </html>

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -12,6 +12,7 @@
         <a href="attendance.html">Attendance</a> |
         <a href="dashboard.html">Dashboard</a> |
         <a href="#" id="logout">Logout</a>
+        <span id="user-role" class="role-label"></span>
     </nav>
     <section>
         <textarea id="report-text" rows="10" cols="60" placeholder="Write your report in Markdown..."></textarea><br>

--- a/frontend/src/attendance.js
+++ b/frontend/src/attendance.js
@@ -11,17 +11,31 @@ function showAttendance(msg) {
     document.getElementById('attendance-msg').textContent = msg;
 }
 
+function formatTime(iso) {
+    const d = new Date(iso);
+    const hh = d.getHours().toString().padStart(2, '0');
+    const mm = d.getMinutes().toString().padStart(2, '0');
+    return `${hh}:${mm}`;
+}
+
+async function loadUserRole() {
+    const info = await apiRequest('/me');
+    if (info.role) {
+        document.getElementById('user-role').textContent = info.role;
+    }
+}
+
 async function clockIn() {
     const data = await apiRequest('/attendance/clock-in', { method: 'POST' });
     if (data.timestamp) {
-        showAttendance(`Clocked in at ${data.timestamp}`);
+        showAttendance(`Clocked in at ${formatTime(data.timestamp)}`);
     }
 }
 
 async function clockOut() {
     const data = await apiRequest('/attendance/clock-out', { method: 'POST' });
     if (data.timestamp) {
-        showAttendance(`Clocked out at ${data.timestamp}`);
+        showAttendance(`Clocked out at ${formatTime(data.timestamp)}`);
     }
 }
 
@@ -31,3 +45,5 @@ document.getElementById('logout').addEventListener('click', async () => {
     await apiRequest('/logout', { method: 'POST' });
     location.href = 'login.html';
 });
+
+loadUserRole();

--- a/frontend/src/dashboard.js
+++ b/frontend/src/dashboard.js
@@ -13,8 +13,15 @@ async function loadDashboard() {
     container.innerHTML = '';
     for (const [user, hours] of Object.entries(data)) {
         const div = document.createElement('div');
-        div.textContent = `User ${user}: ${hours.toFixed(2)} hours`;
+        div.textContent = `${user}: ${hours.toFixed(2)} hours`;
         container.appendChild(div);
+    }
+}
+
+async function loadUserRole() {
+    const info = await apiRequest('/me');
+    if (info.role) {
+        document.getElementById('user-role').textContent = info.role;
     }
 }
 
@@ -24,3 +31,4 @@ document.getElementById('logout').addEventListener('click', async () => {
 });
 
 loadDashboard();
+loadUserRole();

--- a/frontend/src/report.js
+++ b/frontend/src/report.js
@@ -7,6 +7,20 @@ async function apiRequest(path, options) {
     return res.json();
 }
 
+function formatTime(iso) {
+    const d = new Date(iso);
+    const hh = d.getHours().toString().padStart(2, '0');
+    const mm = d.getMinutes().toString().padStart(2, '0');
+    return `${hh}:${mm}`;
+}
+
+async function loadUserRole() {
+    const info = await apiRequest('/me');
+    if (info.role) {
+        document.getElementById('user-role').textContent = info.role;
+    }
+}
+
 async function submitReport() {
     const content = document.getElementById('report-text').value;
     const res = await apiRequest('/report/', {
@@ -29,7 +43,7 @@ async function loadReports() {
     if (!Array.isArray(reports)) return;
     reports.forEach(r => {
         const div = document.createElement('div');
-        div.innerHTML = `<strong>${r.timestamp}</strong><div>` + marked.parse(r.content) + '</div>';
+        div.innerHTML = `<strong>${formatTime(r.timestamp)}</strong><div>` + marked.parse(r.content) + '</div>';
         container.appendChild(div);
     });
 }
@@ -45,3 +59,4 @@ document.getElementById('logout').addEventListener('click', async () => {
 });
 
 loadReports();
+loadUserRole();

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,3 +1,4 @@
 body { font-family: Arial, sans-serif; margin: 20px; }
 #attendance-msg { margin-top: 10px; font-weight: bold; }
 #reports div { border-bottom: 1px solid #ccc; padding: 10px 0; }
+.role-label { font-size: 0.8em; color: #555; margin-left: 8px; }


### PR DESCRIPTION
## Summary
- let users jump from register page back to login
- show logged-in user role on each page
- include user names in dashboard summaries
- add `/me` endpoint and send role on login
- format timestamps as `HH:MM`

## Testing
- `npm install`
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685a330149108324b4c9b040ec580307