### PR TITLE
Update dashboard and UI for Japanese locale

### DIFF
--- a/frontend/attendance.html
+++ b/frontend/attendance.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <title>Attendance</title>
+    <title>勤怠管理</title>
     <script src="src/vendor/marked.min.js"></script>
     <link rel="stylesheet" href="src/style.css">
 </head>
 <body>
-    <h1>Attendance & Daily Report</h1>
+    <h1>勤怠管理</h1>
+    <span id="user-role" class="role-label"></span>
     <nav>
-        <a href="report.html">Report</a> |
-        <a href="dashboard.html">Dashboard</a> |
-        <a href="#" id="logout">Logout</a>
-        <span id="user-role" class="role-label"></span>
+        <a href="report.html">日報</a> |
+        <a href="dashboard.html">ダッシュボード</a> |
+        <a href="#" id="logout">ログアウト</a>
     </nav>
     <section>
-        <button id="clock-in">Clock In</button>
-        <button id="clock-out">Clock Out</button>
+        <button id="clock-in">出勤</button>
+        <button id="clock-out">退勤</button>
         <div id="attendance-msg"></div>
     </section>
     <script src="src/attendance.js"></script>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <title>Dashboard</title>
+    <title>ダッシュボード</title>
     <link rel="stylesheet" href="src/style.css">
 </head>
 <body>
-    <h1>Dashboard</h1>
+    <h1>ダッシュボード</h1>
+    <span id="user-role" class="role-label"></span>
     <nav>
-        <a href="attendance.html">Attendance</a> |
-        <a href="report.html">Report</a> |
-        <a href="#" id="logout">Logout</a>
-        <span id="user-role" class="role-label"></span>
+        <a href="attendance.html">勤怠管理</a> |
+        <a href="report.html">日報</a> |
+        <a href="#" id="logout">ログアウト</a>
     </nav>
     <div id="dashboard-data"></div>
     <script src="src/dashboard.js"></script>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <title>Login</title>
+    <title>ログイン</title>
     <link rel="stylesheet" href="src/style.css">
 </head>
 <body>
-    <h1>Demo Login</h1>
+    <h1>ログイン</h1>
     <form id="login-form">
-        <input type="email" id="email" placeholder="Email" required><br>
-        <input type="password" id="password" placeholder="Password" required><br>
-        <button type="submit">Login</button>
+        <input type="email" id="email" placeholder="メールアドレス" required><br>
+        <input type="password" id="password" placeholder="パスワード" required><br>
+        <button type="submit">ログイン</button>
     </form>
-    <p><a href="register.html">Register</a></p>
+    <p><a href="register.html">新規登録</a></p>
     <script src="src/login.js"></script>
 </body>
 </html>

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -1,23 +1,23 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <title>Register</title>
+    <title>ユーザー登録</title>
     <link rel="stylesheet" href="src/style.css">
 </head>
 <body>
-    <h1>Register</h1>
+    <h1>ユーザー登録</h1>
     <form id="register-form">
-        <input type="text" id="name" placeholder="Name" required><br>
-        <input type="email" id="email" placeholder="Email" required><br>
-        <input type="password" id="password" placeholder="Password" required><br>
+        <input type="text" id="name" placeholder="氏名" required><br>
+        <input type="email" id="email" placeholder="メールアドレス" required><br>
+        <input type="password" id="password" placeholder="パスワード" required><br>
         <select id="role">
-            <option value="user">General</option>
-            <option value="admin">Admin</option>
+            <option value="user">一般</option>
+            <option value="admin">管理者</option>
         </select><br>
-        <button type="submit">Create</button>
+        <button type="submit">作成</button>
     </form>
-    <p><a href="login.html">Back to Login</a></p>
+    <p><a href="login.html">ログインへ戻る</a></p>
     <script src="src/register.js"></script>
 </body>
 </html>

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -1,29 +1,34 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <title>Daily Report</title>
+    <title>日報</title>
     <script src="src/vendor/marked.min.js"></script>
     <link rel="stylesheet" href="src/style.css">
 </head>
 <body>
-    <h1>Daily Report</h1>
+    <h1>日報</h1>
+    <span id="user-role" class="role-label"></span>
     <nav>
-        <a href="attendance.html">Attendance</a> |
-        <a href="dashboard.html">Dashboard</a> |
-        <a href="#" id="logout">Logout</a>
-        <span id="user-role" class="role-label"></span>
+        <a href="attendance.html">勤怠管理</a> |
+        <a href="dashboard.html">ダッシュボード</a> |
+        <a href="#" id="logout">ログアウト</a>
     </nav>
     <section>
-        <textarea id="report-text" rows="10" cols="60" placeholder="Write your report in Markdown..."></textarea><br>
-        <button id="preview">Preview</button>
-        <button id="submit-report">Submit Report</button>
-        <div id="preview-area"></div>
+        <textarea id="report-text" rows="10" cols="60" placeholder="Markdown形式で日報を書いてください..."></textarea><br>
+        <button id="preview">プレビュー</button>
+        <button id="submit-report">送信</button>
     </section>
     <section>
-        <h2>Submitted Reports</h2>
+        <h2>送信済みの日報</h2>
         <div id="reports"></div>
     </section>
+    <div id="preview-modal" class="modal">
+        <div class="modal-content">
+            <span id="close-preview" class="close-button">&times;</span>
+            <div id="modal-body"></div>
+        </div>
+    </div>
     <script src="src/report.js"></script>
 </body>
 </html>

--- a/frontend/src/attendance.js
+++ b/frontend/src/attendance.js
@@ -13,29 +13,33 @@ function showAttendance(msg) {
 
 function formatTime(iso) {
     const d = new Date(iso);
-    const hh = d.getHours().toString().padStart(2, '0');
-    const mm = d.getMinutes().toString().padStart(2, '0');
-    return `${hh}:${mm}`;
+    return d.toLocaleString('ja-JP', {
+        timeZone: 'Asia/Tokyo',
+        hour12: false,
+        hour: '2-digit',
+        minute: '2-digit'
+    });
 }
 
 async function loadUserRole() {
     const info = await apiRequest('/me');
     if (info.role) {
-        document.getElementById('user-role').textContent = info.role;
+        const roleLabel = info.role === 'admin' ? '管理者' : '一般';
+        document.getElementById('user-role').textContent = roleLabel;
     }
 }
 
 async function clockIn() {
     const data = await apiRequest('/attendance/clock-in', { method: 'POST' });
     if (data.timestamp) {
-        showAttendance(`Clocked in at ${formatTime(data.timestamp)}`);
+        showAttendance(`出勤: ${formatTime(data.timestamp)}`);
     }
 }
 
 async function clockOut() {
     const data = await apiRequest('/attendance/clock-out', { method: 'POST' });
     if (data.timestamp) {
-        showAttendance(`Clocked out at ${formatTime(data.timestamp)}`);
+        showAttendance(`退勤: ${formatTime(data.timestamp)}`);
     }
 }
 

--- a/frontend/src/dashboard.js
+++ b/frontend/src/dashboard.js
@@ -1,3 +1,18 @@
+let currentRole = 'user';
+
+function formatDateTime(iso) {
+    const d = new Date(iso);
+    return d.toLocaleString('ja-JP', {
+        timeZone: 'Asia/Tokyo',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+    });
+}
+
 async function apiRequest(path, options) {
     const res = await fetch(path, options);
     if (res.status === 401) {
@@ -11,17 +26,42 @@ async function loadDashboard() {
     const data = await apiRequest('/dashboard');
     const container = document.getElementById('dashboard-data');
     container.innerHTML = '';
-    for (const [user, hours] of Object.entries(data)) {
-        const div = document.createElement('div');
-        div.textContent = `${user}: ${hours.toFixed(2)} hours`;
-        container.appendChild(div);
+    const table = document.createElement('table');
+    let header = '<tr>';
+    if (currentRole === 'admin') {
+        header += '<th>ユーザー名</th>';
     }
+    header += '<th>出勤日時</th><th>退勤日時</th><th>勤務時間</th>';
+    if (currentRole === 'admin') {
+        header += '<th>当月総計</th>';
+    }
+    header += '</tr>';
+    table.innerHTML = '<thead>' + header + '</thead>';
+    const tbody = document.createElement('tbody');
+    data.records.forEach(rec => {
+        let row = '<tr>';
+        if (currentRole === 'admin') {
+            row += `<td>${rec.name}</td>`;
+        }
+        row += `<td>${formatDateTime(rec.clock_in)}</td>`;
+        row += `<td>${formatDateTime(rec.clock_out)}</td>`;
+        row += `<td>${rec.hours.toFixed(2)}</td>`;
+        if (currentRole === 'admin') {
+            row += `<td>${data.totals[rec.name].toFixed(2)}</td>`;
+        }
+        row += '</tr>';
+        tbody.innerHTML += row;
+    });
+    table.appendChild(tbody);
+    container.appendChild(table);
 }
 
 async function loadUserRole() {
     const info = await apiRequest('/me');
     if (info.role) {
-        document.getElementById('user-role').textContent = info.role;
+        currentRole = info.role;
+        const label = info.role === 'admin' ? '管理者' : '一般';
+        document.getElementById('user-role').textContent = label;
     }
 }
 

--- a/frontend/src/login.js
+++ b/frontend/src/login.js
@@ -15,6 +15,6 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
     if (res.status === 'logged_in') {
         location.href = 'attendance.html';
     } else {
-        alert(res.error || 'Login failed');
+        alert(res.error || 'ログインに失敗しました');
     }
 });

--- a/frontend/src/register.js
+++ b/frontend/src/register.js
@@ -15,9 +15,9 @@ document.getElementById('register-form').addEventListener('submit', async (e) =>
         body: JSON.stringify({ name, email, password, role })
     });
     if (res.status === 'registered') {
-        alert('Registered! Please login.');
+        alert('登録完了！ログインしてください。');
         location.href = 'login.html';
     } else {
-        alert(res.error || 'Registration failed');
+        alert(res.error || '登録に失敗しました');
     }
 });

--- a/frontend/src/report.js
+++ b/frontend/src/report.js
@@ -9,15 +9,19 @@ async function apiRequest(path, options) {
 
 function formatTime(iso) {
     const d = new Date(iso);
-    const hh = d.getHours().toString().padStart(2, '0');
-    const mm = d.getMinutes().toString().padStart(2, '0');
-    return `${hh}:${mm}`;
+    return d.toLocaleString('ja-JP', {
+        timeZone: 'Asia/Tokyo',
+        hour12: false,
+        hour: '2-digit',
+        minute: '2-digit'
+    });
 }
 
 async function loadUserRole() {
     const info = await apiRequest('/me');
     if (info.role) {
-        document.getElementById('user-role').textContent = info.role;
+        const roleLabel = info.role === 'admin' ? '管理者' : '一般';
+        document.getElementById('user-role').textContent = roleLabel;
     }
 }
 
@@ -32,7 +36,7 @@ async function submitReport() {
         document.getElementById('report-text').value = '';
         loadReports();
     } else {
-        alert(res.error || 'Failed to submit');
+        alert(res.error || '送信に失敗しました');
     }
 }
 
@@ -51,7 +55,11 @@ async function loadReports() {
 document.getElementById('submit-report').addEventListener('click', submitReport);
 document.getElementById('preview').addEventListener('click', () => {
     const content = document.getElementById('report-text').value;
-    document.getElementById('preview-area').innerHTML = marked.parse(content);
+    document.getElementById('modal-body').innerHTML = marked.parse(content);
+    document.getElementById('preview-modal').style.display = 'flex';
+});
+document.getElementById('close-preview').addEventListener('click', () => {
+    document.getElementById('preview-modal').style.display = 'none';
 });
 document.getElementById('logout').addEventListener('click', async () => {
     await apiRequest('/logout', { method: 'POST' });

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,4 +1,11 @@
 body { font-family: Arial, sans-serif; margin: 20px; }
 #attendance-msg { margin-top: 10px; font-weight: bold; }
 #reports div { border-bottom: 1px solid #ccc; padding: 10px 0; }
-.role-label { font-size: 0.8em; color: #555; margin-left: 8px; }
+.role-label { font-size: 0.8em; color: #555; margin-left: 8px; display: block; }
+table { border-collapse: collapse; width: 100%; margin-top: 10px; }
+th, td { border: 1px solid #ccc; padding: 4px 8px; }
+.modal { position: fixed; top: 0; left: 0; width: 100%; height: 100%;
+         background: rgba(0,0,0,0.5); display: none; justify-content: center;
+         align-items: center; }
+.modal-content { background: #fff; padding: 20px; max-width: 90%; max-height: 90%; overflow: auto; }
+.close-button { cursor: pointer; float: right; }


### PR DESCRIPTION
## Summary
- switch backend timestamps to JST
- redesign dashboard API and table display
- show user role below page titles
- translate UI to Japanese and format times as HH:MM
- add preview modal for daily reports

## Testing
- `python -m py_compile backend/app.py`
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_685a3bd770508324bac2e101230b9437