### PR TITLE
Split dashboard pages for user and admin

### DIFF
--- a/frontend/attendance.html
+++ b/frontend/attendance.html
@@ -34,7 +34,7 @@
         <div class="flex flex-1 justify-end gap-8 items-center">
           <span id="user-role" class="role-label"></span>
           <div class="flex items-center gap-9">
-            <a class="text-[#111418] text-sm font-medium" href="dashboard.html">Dashboard</a>
+            <a class="text-[#111418] text-sm font-medium" id="dashboard-link" href="dashboard_user.html">Dashboard</a>
             <a class="text-[#111418] text-sm font-medium" href="report.html">Reports</a>
           </div>
           <a id="logout" class="text-[#111418] text-sm font-medium" href="#">Logout</a>

--- a/frontend/dashboard_admin.html
+++ b/frontend/dashboard_admin.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin />
+    <link
+      rel="stylesheet"
+      as="style"
+      onload="this.rel='stylesheet'"
+      href="https://fonts.googleapis.com/css2?display=swap&family=Inter:wght@400;500;700;900&family=Noto+Sans:wght@400;500;700;900"
+    />
+    <title>ダッシュボード</title>
+    <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <link rel="stylesheet" href="src/style.css" />
+  </head>
+  <body class="relative flex min-h-screen flex-col bg-neutral-50 overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+    <div class="layout-container flex h-full grow flex-col">
+      <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#ededed] px-10 py-3">
+        <div class="flex items-center gap-4 text-[#141414]">
+          <div class="size-4">
+            <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M39.475 21.6262C40.358 21.4363 40.6863 21.5589 40.7581 21.5934C40.7876 21.655 40.8547 21.857 40.8082 22.3336C40.7408 23.0255 40.4502 24.0046 39.8572 25.2301C38.6799 27.6631 36.5085 30.6631 33.5858 33.5858C30.6631 36.5085 27.6632 38.6799 25.2301 39.8572C24.0046 40.4502 23.0255 40.7407 22.3336 40.8082C21.8571 40.8547 21.6551 40.7875 21.5934 40.7581C21.5589 40.6863 21.4363 40.358 21.6262 39.475C21.8562 38.4054 22.4689 36.9657 23.5038 35.2817C24.7575 33.2417 26.5497 30.9744 28.7621 28.762C30.9744 26.5497 33.2417 24.7574 35.2817 23.5037C36.9657 22.4689 38.4054 21.8562 39.475 21.6262ZM4.41189 29.2403L18.7597 43.5881C19.8813 44.7097 21.4027 44.9179 22.7217 44.7893C24.0585 44.659 25.5148 44.1631 26.9723 43.4579C29.9052 42.0387 33.2618 39.5667 36.4142 36.4142C39.5667 33.2618 42.0387 29.9052 43.4579 26.9723C44.1631 25.5148 44.659 24.0585 44.7893 22.7217C44.9179 21.4027 44.7097 19.8813 43.5881 18.7597L29.2403 4.41187C27.8527 3.02428 25.8765 3.02573 24.2861 3.36776C22.6081 3.72863 20.7334 4.58419 18.8396 5.74801C16.4978 7.18716 13.9881 9.18353 11.5858 11.5858C9.18354 13.988 7.18717 16.4978 5.74802 18.8396C4.58421 20.7334 3.72865 22.6081 3.36778 24.2861C3.02574 25.8765 3.02429 27.8527 4.41189 29.2403Z" fill="currentColor" />
+            </svg>
+          </div>
+          <h2 class="text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em]">WorkWise</h2>
+        </div>
+        <div class="flex flex-1 justify-end gap-8 items-center">
+          <span id="user-role" class="role-label"></span>
+          <div class="flex items-center gap-9">
+            <a class="text-[#141414] text-sm font-medium leading-normal" id="dashboard-link" href="dashboard_admin.html">Dashboard</a>
+            <a class="text-[#141414] text-sm font-medium leading-normal" href="report.html">Reports</a>
+            <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Analytics</a>
+            <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Settings</a>
+          </div>
+          <div class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10" style='background-image: url("https://lh3.googleusercontent.com/a-/ACB-R5Q5")'></div>
+          <a id="logout" class="text-[#141414] text-sm font-medium leading-normal" href="#">Logout</a>
+        </div>
+      </header>
+      <div class="px-40 flex flex-1 justify-center py-5">
+        <div class="layout-content-container flex flex-col max-w-[960px] flex-1">
+          <div class="flex flex-wrap justify-between gap-3 p-4">
+            <div class="flex min-w-72 flex-col gap-3">
+              <p class="text-[#141414] tracking-light text-[32px] font-bold leading-tight">Dashboard</p>
+              <p class="text-neutral-500 text-sm font-normal leading-normal">Welcome back!</p>
+            </div>
+          </div>
+          <div class="flex flex-wrap gap-4 p-4">
+            <div class="flex min-w-[158px] flex-1 flex-col gap-2 rounded-xl p-6 bg-[#ededed]">
+              <p class="text-[#141414] text-base font-medium leading-normal">Total Working Hours</p>
+              <p id="total-hours-value" class="text-[#141414] tracking-light text-2xl font-bold leading-tight">0</p>
+            </div>
+            <div class="flex min-w-[158px] flex-1 flex-col gap-2 rounded-xl p-6 bg-[#ededed]">
+              <p class="text-[#141414] text-base font-medium leading-normal">Utilization Rate</p>
+              <p id="utilization-rate-value" class="text-[#141414] tracking-light text-2xl font-bold leading-tight">0%</p>
+            </div>
+          </div>
+          <h2 class="text-[#141414] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">Monthly Report</h2>
+          <div class="flex flex-wrap gap-4 px-4 py-6">
+            <div class="flex min-w-72 flex-1 flex-col gap-2 rounded-xl border border-[#dbdbdb] p-6">
+              <p class="text-[#141414] text-base font-medium leading-normal">Monthly Working Hours</p>
+              <p id="monthly-hours" class="text-[#141414] tracking-light text-[32px] font-bold leading-tight truncate">0 hours</p>
+              <div class="flex gap-1">
+                <p class="text-neutral-500 text-base font-normal leading-normal">This Month</p>
+                <p id="monthly-change" class="text-[#078807] text-base font-medium leading-normal">0%</p>
+              </div>
+              <div id="weekly-chart" class="grid min-h-[180px] grid-flow-col gap-6 grid-rows-[1fr_auto] items-end justify-items-center px-3"></div>
+            </div>
+          </div>
+          <div class="px-4 py-3 @container">
+            <div class="flex overflow-hidden rounded-lg border border-[#dce0e5] bg-white">
+              <div id="dashboard-data" class="flex-1"></div>
+            </div>
+          </div>
+          <div class="flex px-4 py-3 justify-end">
+            <button class="flex min-w-[84px] max-w-[480px] items-center justify-center h-10 px-4 rounded-lg bg-[#f0f2f4] text-[#141414] text-sm font-bold">
+              <span class="truncate">Export to CSV</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script src="src/dashboard_admin.js"></script>
+  </body>
+</html>

--- a/frontend/dashboard_user.html
+++ b/frontend/dashboard_user.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin />
+    <link
+      rel="stylesheet"
+      as="style"
+      onload="this.rel='stylesheet'"
+      href="https://fonts.googleapis.com/css2?display=swap&family=Inter:wght@400;500;700;900&family=Noto+Sans:wght@400;500;700;900"
+    />
+    <title>ダッシュボード</title>
+    <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <link rel="stylesheet" href="src/style.css" />
+  </head>
+  <body class="relative flex min-h-screen flex-col bg-neutral-50 overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+    <div class="layout-container flex h-full grow flex-col">
+      <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#ededed] px-10 py-3">
+        <div class="flex items-center gap-4 text-[#141414]">
+          <div class="size-4">
+            <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M39.475 21.6262C40.358 21.4363 40.6863 21.5589 40.7581 21.5934C40.7876 21.655 40.8547 21.857 40.8082 22.3336C40.7408 23.0255 40.4502 24.0046 39.8572 25.2301C38.6799 27.6631 36.5085 30.6631 33.5858 33.5858C30.6631 36.5085 27.6632 38.6799 25.2301 39.8572C24.0046 40.4502 23.0255 40.7407 22.3336 40.8082C21.8571 40.8547 21.6551 40.7875 21.5934 40.7581C21.5589 40.6863 21.4363 40.358 21.6262 39.475C21.8562 38.4054 22.4689 36.9657 23.5038 35.2817C24.7575 33.2417 26.5497 30.9744 28.7621 28.762C30.9744 26.5497 33.2417 24.7574 35.2817 23.5037C36.9657 22.4689 38.4054 21.8562 39.475 21.6262ZM4.41189 29.2403L18.7597 43.5881C19.8813 44.7097 21.4027 44.9179 22.7217 44.7893C24.0585 44.659 25.5148 44.1631 26.9723 43.4579C29.9052 42.0387 33.2618 39.5667 36.4142 36.4142C39.5667 33.2618 42.0387 29.9052 43.4579 26.9723C44.1631 25.5148 44.659 24.0585 44.7893 22.7217C44.9179 21.4027 44.7097 19.8813 43.5881 18.7597L29.2403 4.41187C27.8527 3.02428 25.8765 3.02573 24.2861 3.36776C22.6081 3.72863 20.7334 4.58419 18.8396 5.74801C16.4978 7.18716 13.9881 9.18353 11.5858 11.5858C9.18354 13.988 7.18717 16.4978 5.74802 18.8396C4.58421 20.7334 3.72865 22.6081 3.36778 24.2861C3.02574 25.8765 3.02429 27.8527 4.41189 29.2403Z" fill="currentColor" />
+            </svg>
+          </div>
+          <h2 class="text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em]">WorkWise</h2>
+        </div>
+        <div class="flex flex-1 justify-end gap-8 items-center">
+          <span id="user-role" class="role-label"></span>
+          <div class="flex items-center gap-9">
+            <a class="text-[#141414] text-sm font-medium leading-normal" id="dashboard-link" href="dashboard_user.html">Dashboard</a>
+            <a class="text-[#141414] text-sm font-medium leading-normal" href="report.html">Reports</a>
+            <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Analytics</a>
+            <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Settings</a>
+          </div>
+          <div class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10" style='background-image: url("https://lh3.googleusercontent.com/a-/ACB-R5Q5")'></div>
+          <a id="logout" class="text-[#141414] text-sm font-medium leading-normal" href="#">Logout</a>
+        </div>
+      </header>
+      <div class="px-40 flex flex-1 justify-center py-5">
+        <div class="layout-content-container flex flex-col max-w-[960px] flex-1">
+          <div class="flex flex-wrap justify-between gap-3 p-4">
+            <div class="flex min-w-72 flex-col gap-3">
+              <p class="text-[#141414] tracking-light text-[32px] font-bold leading-tight">Dashboard</p>
+              <p class="text-neutral-500 text-sm font-normal leading-normal">Welcome back!</p>
+            </div>
+          </div>
+          <div class="flex flex-wrap gap-4 p-4">
+            <div class="flex min-w-[158px] flex-1 flex-col gap-2 rounded-xl p-6 bg-[#ededed]">
+              <p class="text-[#141414] text-base font-medium leading-normal">Total Working Hours</p>
+              <p id="total-hours-value" class="text-[#141414] tracking-light text-2xl font-bold leading-tight">0</p>
+            </div>
+            <div class="flex min-w-[158px] flex-1 flex-col gap-2 rounded-xl p-6 bg-[#ededed]">
+              <p class="text-[#141414] text-base font-medium leading-normal">Utilization Rate</p>
+              <p id="utilization-rate-value" class="text-[#141414] tracking-light text-2xl font-bold leading-tight">0%</p>
+            </div>
+          </div>
+          <h2 class="text-[#141414] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">Monthly Report</h2>
+          <div class="flex flex-wrap gap-4 px-4 py-6">
+            <div class="flex min-w-72 flex-1 flex-col gap-2 rounded-xl border border-[#dbdbdb] p-6">
+              <p class="text-[#141414] text-base font-medium leading-normal">Monthly Working Hours</p>
+              <p id="monthly-hours" class="text-[#141414] tracking-light text-[32px] font-bold leading-tight truncate">0 hours</p>
+              <div class="flex gap-1">
+                <p class="text-neutral-500 text-base font-normal leading-normal">This Month</p>
+                <p id="monthly-change" class="text-[#078807] text-base font-medium leading-normal">0%</p>
+              </div>
+              <div id="weekly-chart" class="grid min-h-[180px] grid-flow-col gap-6 grid-rows-[1fr_auto] items-end justify-items-center px-3"></div>
+            </div>
+          </div>
+          <div class="px-4 py-3 @container">
+            <div class="flex overflow-hidden rounded-lg border border-[#dce0e5] bg-white">
+              <div id="dashboard-data" class="flex-1"></div>
+            </div>
+          </div>
+          <div class="flex px-4 py-3 justify-end">
+            <button class="flex min-w-[84px] max-w-[480px] items-center justify-center h-10 px-4 rounded-lg bg-[#f0f2f4] text-[#141414] text-sm font-bold">
+              <span class="truncate">Export to CSV</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script src="src/dashboard_user.js"></script>
+  </body>
+</html>

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -34,7 +34,7 @@
         <div class="flex flex-1 justify-end gap-8 items-center">
           <span id="user-role" class="role-label"></span>
           <div class="flex items-center gap-9">
-            <a class="text-[#111418] text-sm font-medium" href="dashboard.html">Dashboard</a>
+            <a class="text-[#111418] text-sm font-medium" id="dashboard-link" href="dashboard_user.html">Dashboard</a>
             <a class="text-[#111418] text-sm font-medium" href="report.html">Reports</a>
           </div>
           <a id="logout" class="text-[#111418] text-sm font-medium" href="#">Logout</a>

--- a/frontend/src/attendance.js
+++ b/frontend/src/attendance.js
@@ -26,6 +26,10 @@ async function loadUserRole() {
     if (info.role) {
         const roleLabel = info.role === 'admin' ? '管理者' : '一般';
         document.getElementById('user-role').textContent = roleLabel;
+        const link = document.getElementById('dashboard-link');
+        if (link) {
+            link.href = info.role === 'admin' ? 'dashboard_admin.html' : 'dashboard_user.html';
+        }
     }
 }
 

--- a/frontend/src/dashboard_admin.js
+++ b/frontend/src/dashboard_admin.js
@@ -1,0 +1,116 @@
+let currentRole = 'admin';
+
+function formatDateTime(iso) {
+    const d = new Date(iso);
+    return d.toLocaleString('ja-JP', {
+        timeZone: 'Asia/Tokyo',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+    });
+}
+
+async function apiRequest(path, options) {
+    const res = await fetch(path, options);
+    if (res.status === 401) {
+        location.href = 'login.html';
+        return {};
+    }
+    return res.json();
+}
+
+function renderWeeklyChart(weeks) {
+    const chart = document.getElementById('weekly-chart');
+    chart.innerHTML = '';
+    const max = Math.max(...weeks, 1);
+    weeks.forEach((h, i) => {
+        const bar = document.createElement('div');
+        bar.className = 'border-neutral-500 bg-[#ededed] border-t-2 w-full';
+        bar.style.height = `${(h / max) * 100}%`;
+        chart.appendChild(bar);
+        const label = document.createElement('p');
+        label.className = 'text-neutral-500 text-[13px] font-bold leading-normal tracking-[0.015em]';
+        label.textContent = `Week ${i + 1}`;
+        chart.appendChild(label);
+    });
+}
+
+async function loadDashboard() {
+    const data = await apiRequest('/dashboard');
+    const container = document.getElementById('dashboard-data');
+    container.innerHTML = '';
+
+    const table = document.createElement('table');
+    table.className = 'min-w-full text-sm';
+
+    let header = '<tr>';
+    if (currentRole === 'admin') {
+        header += '<th class="px-4 py-3 text-left text-[#111418] font-medium">ユーザー名</th>';
+    }
+    header += '<th class="px-4 py-3 text-left text-[#111418] font-medium">出勤日時</th>';
+    header += '<th class="px-4 py-3 text-left text-[#111418] font-medium">退勤日時</th>';
+    header += '<th class="px-4 py-3 text-left text-[#111418] font-medium">勤務時間</th>';
+    if (currentRole === 'admin') {
+        header += '<th class="px-4 py-3 text-left text-[#111418] font-medium">当月総計</th>';
+    }
+    header += '</tr>';
+
+    table.innerHTML = '<thead>' + header + '</thead>';
+
+    const tbody = document.createElement('tbody');
+    data.records.forEach(rec => {
+        let row = '<tr class="border-t border-[#dce0e5]">';
+        if (currentRole === 'admin') {
+            row += `<td class="px-4 py-2 text-[#111418]">${rec.name}</td>`;
+        }
+        row += `<td class="px-4 py-2 text-[#637588]">${formatDateTime(rec.clock_in)}</td>`;
+        row += `<td class="px-4 py-2 text-[#637588]">${formatDateTime(rec.clock_out)}</td>`;
+        row += `<td class="px-4 py-2 text-[#637588]">${rec.hours.toFixed(2)}</td>`;
+        if (currentRole === 'admin') {
+            row += `<td class="px-4 py-2 text-[#111418]">${data.totals[rec.name].toFixed(2)}</td>`;
+        }
+        row += '</tr>';
+        tbody.innerHTML += row;
+    });
+    table.appendChild(tbody);
+    container.appendChild(table);
+
+    // calculate metrics
+    const totalHours = Object.values(data.totals).reduce((a, b) => a + b, 0);
+    document.getElementById('total-hours-value').textContent = totalHours.toFixed(0);
+    document.getElementById('monthly-hours').textContent = `${totalHours.toFixed(0)} hours`;
+
+    const utilization = Math.round((totalHours / 160) * 100);
+    document.getElementById('utilization-rate-value').textContent = utilization + '%';
+
+    // weekly chart
+    const weeks = [0,0,0,0,0];
+    data.records.forEach(r => {
+        const d = new Date(r.clock_in);
+        const week = Math.min(4, Math.floor((d.getDate() - 1) / 7));
+        weeks[week] += r.hours;
+    });
+    renderWeeklyChart(weeks);
+}
+
+async function loadUserRole() {
+    const info = await apiRequest('/me');
+    if (info.role) {
+        if (info.role !== 'admin') {
+            location.href = 'dashboard_user.html';
+            return;
+        }
+        document.getElementById('user-role').textContent = '管理者';
+    }
+}
+
+document.getElementById('logout').addEventListener('click', async () => {
+    await apiRequest('/logout', { method: 'POST' });
+    location.href = 'login.html';
+});
+
+loadDashboard();
+loadUserRole();

--- a/frontend/src/dashboard_user.js
+++ b/frontend/src/dashboard_user.js
@@ -1,0 +1,116 @@
+let currentRole = 'user';
+
+function formatDateTime(iso) {
+    const d = new Date(iso);
+    return d.toLocaleString('ja-JP', {
+        timeZone: 'Asia/Tokyo',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+    });
+}
+
+async function apiRequest(path, options) {
+    const res = await fetch(path, options);
+    if (res.status === 401) {
+        location.href = 'login.html';
+        return {};
+    }
+    return res.json();
+}
+
+function renderWeeklyChart(weeks) {
+    const chart = document.getElementById('weekly-chart');
+    chart.innerHTML = '';
+    const max = Math.max(...weeks, 1);
+    weeks.forEach((h, i) => {
+        const bar = document.createElement('div');
+        bar.className = 'border-neutral-500 bg-[#ededed] border-t-2 w-full';
+        bar.style.height = `${(h / max) * 100}%`;
+        chart.appendChild(bar);
+        const label = document.createElement('p');
+        label.className = 'text-neutral-500 text-[13px] font-bold leading-normal tracking-[0.015em]';
+        label.textContent = `Week ${i + 1}`;
+        chart.appendChild(label);
+    });
+}
+
+async function loadDashboard() {
+    const data = await apiRequest('/dashboard');
+    const container = document.getElementById('dashboard-data');
+    container.innerHTML = '';
+
+    const table = document.createElement('table');
+    table.className = 'min-w-full text-sm';
+
+    let header = '<tr>';
+    if (currentRole === 'admin') {
+        header += '<th class="px-4 py-3 text-left text-[#111418] font-medium">ユーザー名</th>';
+    }
+    header += '<th class="px-4 py-3 text-left text-[#111418] font-medium">出勤日時</th>';
+    header += '<th class="px-4 py-3 text-left text-[#111418] font-medium">退勤日時</th>';
+    header += '<th class="px-4 py-3 text-left text-[#111418] font-medium">勤務時間</th>';
+    if (currentRole === 'admin') {
+        header += '<th class="px-4 py-3 text-left text-[#111418] font-medium">当月総計</th>';
+    }
+    header += '</tr>';
+
+    table.innerHTML = '<thead>' + header + '</thead>';
+
+    const tbody = document.createElement('tbody');
+    data.records.forEach(rec => {
+        let row = '<tr class="border-t border-[#dce0e5]">';
+        if (currentRole === 'admin') {
+            row += `<td class="px-4 py-2 text-[#111418]">${rec.name}</td>`;
+        }
+        row += `<td class="px-4 py-2 text-[#637588]">${formatDateTime(rec.clock_in)}</td>`;
+        row += `<td class="px-4 py-2 text-[#637588]">${formatDateTime(rec.clock_out)}</td>`;
+        row += `<td class="px-4 py-2 text-[#637588]">${rec.hours.toFixed(2)}</td>`;
+        if (currentRole === 'admin') {
+            row += `<td class="px-4 py-2 text-[#111418]">${data.totals[rec.name].toFixed(2)}</td>`;
+        }
+        row += '</tr>';
+        tbody.innerHTML += row;
+    });
+    table.appendChild(tbody);
+    container.appendChild(table);
+
+    // calculate metrics
+    const totalHours = Object.values(data.totals).reduce((a, b) => a + b, 0);
+    document.getElementById('total-hours-value').textContent = totalHours.toFixed(0);
+    document.getElementById('monthly-hours').textContent = `${totalHours.toFixed(0)} hours`;
+
+    const utilization = Math.round((totalHours / 160) * 100);
+    document.getElementById('utilization-rate-value').textContent = utilization + '%';
+
+    // weekly chart
+    const weeks = [0,0,0,0,0];
+    data.records.forEach(r => {
+        const d = new Date(r.clock_in);
+        const week = Math.min(4, Math.floor((d.getDate() - 1) / 7));
+        weeks[week] += r.hours;
+    });
+    renderWeeklyChart(weeks);
+}
+
+async function loadUserRole() {
+    const info = await apiRequest('/me');
+    if (info.role) {
+        if (info.role !== 'user') {
+            location.href = 'dashboard_admin.html';
+            return;
+        }
+        document.getElementById('user-role').textContent = '一般';
+    }
+}
+
+document.getElementById('logout').addEventListener('click', async () => {
+    await apiRequest('/logout', { method: 'POST' });
+    location.href = 'login.html';
+});
+
+loadDashboard();
+loadUserRole();

--- a/frontend/src/report.js
+++ b/frontend/src/report.js
@@ -22,6 +22,10 @@ async function loadUserRole() {
     if (info.role) {
         const roleLabel = info.role === 'admin' ? '管理者' : '一般';
         document.getElementById('user-role').textContent = roleLabel;
+        const link = document.getElementById('dashboard-link');
+        if (link) {
+            link.href = info.role === 'admin' ? 'dashboard_admin.html' : 'dashboard_user.html';
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- create separate dashboard pages for admin and general users
- add scripts that redirect if role mismatches
- update attendance and report pages to point at new dashboards

## Testing
- `npm install`
- `npm audit`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685a60bfa06c8324ae55486ea51b8820