### PR TITLE
Update dashboards and attendance features

### DIFF
--- a/frontend/dashboard_admin.html
+++ b/frontend/dashboard_admin.html
@@ -60,9 +60,6 @@
                       <th class="table-column-120 px-4 py-3 text-left text-[#111418] w-[400px] text-sm font-medium leading-normal">
                         Employee Name
                       </th>
-                      <th class="table-column-240 px-4 py-3 text-left text-[#111418] w-[400px] text-sm font-medium leading-normal">
-                        Department
-                      </th>
                       <th class="table-column-360 px-4 py-3 text-left text-[#111418] w-[400px] text-sm font-medium leading-normal">
                         Total Hours
                       </th>
@@ -76,13 +73,13 @@
               </div>
               <style>
                 @container(max-width:120px){.table-column-120{display: none;}}
-                @container(max-width:240px){.table-column-240{display: none;}}
                 @container(max-width:360px){.table-column-360{display: none;}}
                 @container(max-width:480px){.table-column-480{display: none;}}
               </style>
             </div>
             <div class="flex px-4 py-3 justify-end">
               <button
+                id="export-csv"
                 class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#f0f2f4] text-[#111418] text-sm font-bold leading-normal tracking-[0.015em]"
               >
                 <span class="truncate">Export to CSV</span>

--- a/frontend/dashboard_user.html
+++ b/frontend/dashboard_user.html
@@ -71,11 +71,6 @@
               <div id="dashboard-data" class="flex-1"></div>
             </div>
           </div>
-          <div class="flex px-4 py-3 justify-end">
-            <button class="flex min-w-[84px] max-w-[480px] items-center justify-center h-10 px-4 rounded-lg bg-[#f0f2f4] text-[#141414] text-sm font-bold">
-              <span class="truncate">Export to CSV</span>
-            </button>
-          </div>
         </div>
       </div>
     </div>

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -58,7 +58,7 @@
             </button>
           </div>
           <div class="flex px-4 py-3 justify-start">
-            <button id="submit-report" class="flex min-w-[84px] max-w-[480px] items-center justify-center h-10 px-4 rounded-lg bg-[#197fe5] text-white text-sm font-bold">
+            <button id="submit-report" class="flex min-w-[84px] max-w-[480px] items-center justify-center h-10 px-4 rounded-lg bg-[#197fe5] text-white text-sm font-bold" disabled>
               <span class="truncate">Submit Report</span>
             </button>
           </div>

--- a/frontend/src/attendance.js
+++ b/frontend/src/attendance.js
@@ -11,6 +11,17 @@ function showAttendance(msg) {
     document.getElementById('attendance-msg').textContent = msg;
 }
 
+async function loadTodayAttendance() {
+    const data = await apiRequest('/attendance/today');
+    if (data.clock_in && data.clock_out) {
+        showAttendance(`本日の出勤 ${formatTime(data.clock_in)} 退勤 ${formatTime(data.clock_out)}`);
+    } else if (data.clock_in) {
+        showAttendance(`本日の出勤 ${formatTime(data.clock_in)} 退勤 未打刻`);
+    } else {
+        showAttendance('本日の打刻はありません');
+    }
+}
+
 function formatTime(iso) {
     const d = new Date(iso);
     return d.toLocaleString('ja-JP', {
@@ -49,14 +60,14 @@ async function loadMonthlySummary() {
 async function clockIn() {
     const data = await apiRequest('/attendance/clock-in', { method: 'POST' });
     if (data.timestamp) {
-        showAttendance(`出勤: ${formatTime(data.timestamp)}`);
+        await loadTodayAttendance();
     }
 }
 
 async function clockOut() {
     const data = await apiRequest('/attendance/clock-out', { method: 'POST' });
     if (data.timestamp) {
-        showAttendance(`退勤: ${formatTime(data.timestamp)}`);
+        await loadTodayAttendance();
     }
 }
 
@@ -67,4 +78,7 @@ document.getElementById('logout').addEventListener('click', async () => {
     location.href = 'login.html';
 });
 
-loadUserRole().then(loadMonthlySummary);
+loadUserRole().then(() => {
+    loadMonthlySummary();
+    loadTodayAttendance();
+});

--- a/frontend/src/dashboard_admin.js
+++ b/frontend/src/dashboard_admin.js
@@ -21,7 +21,6 @@ async function loadDashboard() {
         row.className = 'border-t border-t-[#dce0e5]';
         row.innerHTML = `
             <td class="table-column-120 h-[72px] px-4 py-2 w-[400px] text-[#111418] text-sm font-normal leading-normal">${name}</td>
-            <td class="table-column-240 h-[72px] px-4 py-2 w-[400px] text-[#637588] text-sm font-normal leading-normal">N/A</td>
             <td class="table-column-360 h-[72px] px-4 py-2 w-[400px] text-[#637588] text-sm font-normal leading-normal">${hours.toFixed(0)}</td>
             <td class="table-column-480 h-[72px] px-4 py-2 w-[400px] text-sm font-normal leading-normal">
               <div class="flex items-center gap-3">
@@ -55,3 +54,22 @@ document.getElementById('logout').addEventListener('click', async () => {
 
 loadDashboard();
 loadUserRole();
+
+async function exportCsv() {
+    const data = await apiRequest('/dashboard');
+    let csv = 'Employee Name,Total Hours,Utilization Rate\n';
+    Object.keys(data.totals).sort().forEach(name => {
+        const hours = data.totals[name];
+        const utilization = Math.round((hours / 160) * 100);
+        csv += `${name},${hours.toFixed(0)},${utilization}%\n`;
+    });
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'attendance.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+}
+
+document.getElementById('export-csv').addEventListener('click', exportCsv);

--- a/frontend/src/report.js
+++ b/frontend/src/report.js
@@ -30,7 +30,11 @@ async function loadUserRole() {
 }
 
 async function submitReport() {
-    const content = document.getElementById('report-text').value;
+    const content = document.getElementById('report-text').value.trim();
+    if (!content) {
+        alert('日報を入力してください');
+        return;
+    }
     const res = await apiRequest('/report/', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -57,6 +61,9 @@ async function loadReports() {
 }
 
 document.getElementById('submit-report').addEventListener('click', submitReport);
+document.getElementById('report-text').addEventListener('input', (e) => {
+    document.getElementById('submit-report').disabled = e.target.value.trim() === '';
+});
 document.getElementById('preview').addEventListener('click', () => {
     const content = document.getElementById('report-text').value;
     document.getElementById('modal-body').innerHTML = marked.parse(content);
@@ -72,3 +79,4 @@ document.getElementById('logout').addEventListener('click', async () => {
 
 loadReports();
 loadUserRole();
+document.getElementById('submit-report').disabled = true;


### PR DESCRIPTION
## Summary
- remove CSV export button from user dashboard
- drop department column from admin dashboard and add CSV export
- show today's clock-in/out info on attendance page
- add `/attendance/today` API endpoint
- prevent empty daily reports

## Testing
- `python3 -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_685a7e8298d48324ab704dcbd812588c