### PR TITLE
Fix dashboard layout and improve report markdown

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -208,11 +208,15 @@ def list_reports():
     with get_db() as conn:
         if session.get("role") == "admin":
             cur = conn.execute(
-                "SELECT id, user_id, content, timestamp FROM reports ORDER BY id DESC"
+                "SELECT r.id, r.user_id, u.name, r.content, r.timestamp "
+                "FROM reports r JOIN users u ON r.user_id = u.id "
+                "ORDER BY r.id DESC"
             )
         else:
             cur = conn.execute(
-                "SELECT id, user_id, content, timestamp FROM reports WHERE user_id=? ORDER BY id DESC",
+                "SELECT r.id, r.user_id, u.name, r.content, r.timestamp "
+                "FROM reports r JOIN users u ON r.user_id = u.id "
+                "WHERE r.user_id=? ORDER BY r.id DESC",
                 (session["user_id"],),
             )
         rows = [dict(row) for row in cur.fetchall()]

--- a/frontend/dashboard_admin.html
+++ b/frontend/dashboard_admin.html
@@ -17,7 +17,7 @@
   <body>
     <div class="relative flex size-full min-h-screen flex-col bg-white group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
       <div class="layout-container flex h-full grow flex-col">
-        <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#f0f2f4] px-10 py-3">
+        <header class="flex items-center justify-between border-b border-[#f0f2f4] px-10 py-3">
           <div class="flex items-center gap-4 text-[#111418]">
             <div class="size-4">
               <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -31,17 +31,14 @@
             </div>
             <h2 class="text-[#111418] text-lg font-bold leading-tight tracking-[-0.015em]">WorkWise</h2>
           </div>
-          <div class="flex flex-1 justify-end gap-8">
+          <div class="flex flex-1 justify-end gap-8 items-center">
+            <span id="user-role" class="role-label"></span>
             <div class="flex items-center gap-9">
-              <a class="text-[#111418] text-sm font-medium leading-normal" href="attendance.html">Attendance</a>
-              <a class="text-[#111418] text-sm font-medium leading-normal" href="dashboard_admin.html">Dashboard</a>
-              <a class="text-[#111418] text-sm font-medium leading-normal" href="report.html">Reports</a>
+              <a class="text-[#111418] text-sm font-medium" href="attendance.html">Attendance</a>
+              <a class="text-[#111418] text-sm font-medium" href="dashboard_admin.html">Dashboard</a>
+              <a class="text-[#111418] text-sm font-medium" href="report.html">Reports</a>
             </div>
-            <div
-              class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
-              style='background-image: url("https://lh3.googleusercontent.com/a-/ACB-R5Q5")'
-            ></div>
-            <a id="logout" class="text-[#111418] text-sm font-medium leading-normal" href="#">Logout</a>
+            <a id="logout" class="text-[#111418] text-sm font-medium" href="#">Logout</a>
           </div>
         </header>
         <div class="px-40 flex flex-1 justify-center py-5">

--- a/frontend/dashboard_user.html
+++ b/frontend/dashboard_user.html
@@ -16,24 +16,23 @@
   </head>
   <body class="relative flex min-h-screen flex-col bg-neutral-50 overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
     <div class="layout-container flex h-full grow flex-col">
-      <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#ededed] px-10 py-3">
-        <div class="flex items-center gap-4 text-[#141414]">
+      <header class="flex items-center justify-between border-b border-[#f0f2f4] px-10 py-3">
+        <div class="flex items-center gap-4 text-[#111418]">
           <div class="size-4">
             <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path fill-rule="evenodd" clip-rule="evenodd" d="M39.475 21.6262C40.358 21.4363 40.6863 21.5589 40.7581 21.5934C40.7876 21.655 40.8547 21.857 40.8082 22.3336C40.7408 23.0255 40.4502 24.0046 39.8572 25.2301C38.6799 27.6631 36.5085 30.6631 33.5858 33.5858C30.6631 36.5085 27.6632 38.6799 25.2301 39.8572C24.0046 40.4502 23.0255 40.7407 22.3336 40.8082C21.8571 40.8547 21.6551 40.7875 21.5934 40.7581C21.5589 40.6863 21.4363 40.358 21.6262 39.475C21.8562 38.4054 22.4689 36.9657 23.5038 35.2817C24.7575 33.2417 26.5497 30.9744 28.7621 28.762C30.9744 26.5497 33.2417 24.7574 35.2817 23.5037C36.9657 22.4689 38.4054 21.8562 39.475 21.6262ZM4.41189 29.2403L18.7597 43.5881C19.8813 44.7097 21.4027 44.9179 22.7217 44.7893C24.0585 44.659 25.5148 44.1631 26.9723 43.4579C29.9052 42.0387 33.2618 39.5667 36.4142 36.4142C39.5667 33.2618 42.0387 29.9052 43.4579 26.9723C44.1631 25.5148 44.659 24.0585 44.7893 22.7217C44.9179 21.4027 44.7097 19.8813 43.5881 18.7597L29.2403 4.41187C27.8527 3.02428 25.8765 3.02573 24.2861 3.36776C22.6081 3.72863 20.7334 4.58419 18.8396 5.74801C16.4978 7.18716 13.9881 9.18353 11.5858 11.5858C9.18354 13.988 7.18717 16.4978 5.74802 18.8396C4.58421 20.7334 3.72865 22.6081 3.36778 24.2861C3.02574 25.8765 3.02429 27.8527 4.41189 29.2403Z" fill="currentColor" />
             </svg>
           </div>
-          <h2 class="text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em]">WorkWise</h2>
+          <h2 class="text-[#111418] text-lg font-bold leading-tight tracking-[-0.015em]">WorkWise</h2>
         </div>
         <div class="flex flex-1 justify-end gap-8 items-center">
           <span id="user-role" class="role-label"></span>
           <div class="flex items-center gap-9">
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="attendance.html">Attendance</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" id="dashboard-link" href="dashboard_user.html">Dashboard</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="report.html">Reports</a>
+            <a class="text-[#111418] text-sm font-medium" href="attendance.html">Attendance</a>
+            <a class="text-[#111418] text-sm font-medium" id="dashboard-link" href="dashboard_user.html">Dashboard</a>
+            <a class="text-[#111418] text-sm font-medium" href="report.html">Reports</a>
           </div>
-          <div class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10" style='background-image: url("https://lh3.googleusercontent.com/a-/ACB-R5Q5")'></div>
-          <a id="logout" class="text-[#141414] text-sm font-medium leading-normal" href="#">Logout</a>
+          <a id="logout" class="text-[#111418] text-sm font-medium" href="#">Logout</a>
         </div>
       </header>
       <div class="px-40 flex flex-1 justify-center py-5">
@@ -47,7 +46,7 @@
           <div class="flex flex-wrap gap-4 p-4">
             <div class="flex min-w-[158px] flex-1 flex-col gap-2 rounded-xl p-6 bg-[#ededed]">
               <p class="text-[#141414] text-base font-medium leading-normal">Total Working Hours</p>
-              <p id="total-hours-value" class="text-[#141414] tracking-light text-2xl font-bold leading-tight">0</p>
+              <p id="total-hours-value" class="text-[#141414] tracking-light text-2xl font-bold leading-tight">0h 0m</p>
             </div>
             <div class="flex min-w-[158px] flex-1 flex-col gap-2 rounded-xl p-6 bg-[#ededed]">
               <p class="text-[#141414] text-base font-medium leading-normal">Utilization Rate</p>
@@ -58,7 +57,7 @@
           <div class="flex flex-wrap gap-4 px-4 py-6">
             <div class="flex min-w-72 flex-1 flex-col gap-2 rounded-xl border border-[#dbdbdb] p-6">
               <p class="text-[#141414] text-base font-medium leading-normal">Monthly Working Hours</p>
-              <p id="monthly-hours" class="text-[#141414] tracking-light text-[32px] font-bold leading-tight truncate">0 hours</p>
+              <p id="monthly-hours" class="text-[#141414] tracking-light text-[32px] font-bold leading-tight truncate">0h 0m</p>
               <div class="flex gap-1">
                 <p class="text-neutral-500 text-base font-normal leading-normal">This Month</p>
                 <p id="monthly-change" class="text-[#078807] text-base font-medium leading-normal">0%</p>

--- a/frontend/src/dashboard_admin.js
+++ b/frontend/src/dashboard_admin.js
@@ -14,14 +14,18 @@ async function loadDashboard() {
     const tbody = document.getElementById('attendance-body');
     tbody.innerHTML = '';
 
+    const target = getMonthlyTargetHours();
+
     Object.keys(data.totals).sort().forEach(name => {
         const hours = data.totals[name];
-        const utilization = Math.round((hours / 160) * 100);
+        const utilization = Math.round((hours / target) * 100);
         const row = document.createElement('tr');
         row.className = 'border-t border-t-[#dce0e5]';
+        const h = Math.floor(hours);
+        const m = Math.round((hours - h) * 60);
         row.innerHTML = `
             <td class="table-column-120 h-[72px] px-4 py-2 w-[400px] text-[#111418] text-sm font-normal leading-normal">${name}</td>
-            <td class="table-column-360 h-[72px] px-4 py-2 w-[400px] text-[#637588] text-sm font-normal leading-normal">${hours.toFixed(0)}</td>
+            <td class="table-column-360 h-[72px] px-4 py-2 w-[400px] text-[#637588] text-sm font-normal leading-normal">${h}h ${m}m</td>
             <td class="table-column-480 h-[72px] px-4 py-2 w-[400px] text-sm font-normal leading-normal">
               <div class="flex items-center gap-3">
                 <div class="w-[88px] overflow-hidden rounded-sm bg-[#dce0e5]">
@@ -32,6 +36,18 @@ async function loadDashboard() {
             </td>`;
         tbody.appendChild(row);
     });
+}
+
+function getMonthlyTargetHours() {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = now.getMonth();
+    let weekdays = 0;
+    for (let d = new Date(year, month, 1); d.getMonth() === month; d.setDate(d.getDate() + 1)) {
+        const day = d.getDay();
+        if (day !== 0 && day !== 6) weekdays++;
+    }
+    return weekdays * 8;
 }
 
 /* Legacy dashboard widgets were removed. */
@@ -60,8 +76,10 @@ async function exportCsv() {
     let csv = 'Employee Name,Total Hours,Utilization Rate\n';
     Object.keys(data.totals).sort().forEach(name => {
         const hours = data.totals[name];
-        const utilization = Math.round((hours / 160) * 100);
-        csv += `${name},${hours.toFixed(0)},${utilization}%\n`;
+        const utilization = Math.round((hours / getMonthlyTargetHours()) * 100);
+        const h = Math.floor(hours);
+        const m = Math.round((hours - h) * 60);
+        csv += `${name},${h}h ${m}m,${utilization}%\n`;
     });
     const blob = new Blob([csv], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);

--- a/frontend/src/report.js
+++ b/frontend/src/report.js
@@ -11,6 +11,9 @@ function formatTime(iso) {
     const d = new Date(iso);
     return d.toLocaleString('ja-JP', {
         timeZone: 'Asia/Tokyo',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
         hour12: false,
         hour: '2-digit',
         minute: '2-digit'
@@ -55,7 +58,10 @@ async function loadReports() {
     if (!Array.isArray(reports)) return;
     reports.forEach(r => {
         const div = document.createElement('div');
-        div.innerHTML = `<strong>${formatTime(r.timestamp)}</strong><div>` + marked.parse(r.content) + '</div>';
+        const time = formatTime(r.timestamp);
+        const name = r.name || '';
+        div.innerHTML = `<strong>${name}</strong> <span class="text-sm text-[#637588]">${time}</span><div>` +
+            marked.parse(r.content) + '</div>';
         container.appendChild(div);
     });
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -7,5 +7,10 @@ th, td { border: 1px solid #ccc; padding: 4px 8px; }
 .modal { position: fixed; top: 0; left: 0; width: 100%; height: 100%;
          background: rgba(0,0,0,0.5); display: none; justify-content: center;
          align-items: center; }
-.modal-content { background: #fff; padding: 20px; max-width: 90%; max-height: 90%; overflow: auto; }
+.modal-content { background: #fff; padding: 20px; width: 80%; max-width: 600px; max-height: 80vh; overflow: auto; }
+.modal-content h1 { font-size: 1.5em; margin-top: 0.5em; }
+.modal-content h2 { font-size: 1.25em; margin-top: 0.5em; }
+#reports h1, #reports h2 { margin-top: 0.5em; font-weight: bold; }
+#reports ul, #modal-body ul { list-style: disc; margin-left: 1.5em; }
+#reports ol, #modal-body ol { list-style: decimal; margin-left: 1.5em; }
 .close-button { cursor: pointer; float: right; }


### PR DESCRIPTION
## Summary
- align header tabs across pages
- show names and full timestamps for reports
- support markdown styling and fixed preview modal size
- display working hours in `h m` format and use weekdays for utilization

## Testing
- `python3 -m py_compile backend/app.py`
- `npm install --silent` *(failed: unknown)**

------
https://chatgpt.com/codex/tasks/task_e_685a992025348324aaf055aa71bfaa16