### PR TITLE
Fix markdown preview and modal size

### DIFF
--- a/frontend/report.html
+++ b/frontend/report.html
@@ -12,7 +12,8 @@
     <title>日報</title>
     <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-    <script src="src/vendor/marked.min.js"></script>
+    <!-- Load marked from CDN to ensure markdown parsing works -->
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <link rel="stylesheet" href="src/style.css" />
   </head>
   <body class="min-h-screen flex flex-col bg-white" style='font-family: Inter, "Noto Sans", sans-serif; margin: 0;'>

--- a/frontend/src/report.js
+++ b/frontend/src/report.js
@@ -7,6 +7,11 @@ async function apiRequest(path, options) {
     return res.json();
 }
 
+// Ensure line breaks are rendered in markdown output
+if (window.marked) {
+    marked.setOptions({ breaks: true });
+}
+
 function formatTime(iso) {
     const d = new Date(iso);
     return d.toLocaleString('ja-JP', {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -7,7 +7,14 @@ th, td { border: 1px solid #ccc; padding: 4px 8px; }
 .modal { position: fixed; top: 0; left: 0; width: 100%; height: 100%;
          background: rgba(0,0,0,0.5); display: none; justify-content: center;
          align-items: center; }
-.modal-content { background: #fff; padding: 20px; width: 80%; max-width: 600px; max-height: 80vh; overflow: auto; }
+.modal-content {
+  background: #fff;
+  padding: 20px;
+  width: 80%;
+  max-width: 600px;
+  height: 70vh;
+  overflow-y: auto;
+}
 .modal-content h1 { font-size: 1.5em; margin-top: 0.5em; }
 .modal-content h2 { font-size: 1.25em; margin-top: 0.5em; }
 #reports h1, #reports h2 { margin-top: 0.5em; font-weight: bold; }


### PR DESCRIPTION
## Summary
- load marked from CDN to ensure markdown parsing works
- set marked options to render line breaks
- make preview modal a constant size with scrolling

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_685a9eec11e08324ae4f5e926e0b2f2e