### PR TITLE
Fix attendance reload and report features

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -186,6 +186,8 @@ def attendance_today():
             last_in = current_in
             last_out = r["timestamp"]
             current_in = None
+    if current_in and not last_out:
+        last_in = current_in
 
     return jsonify({"clock_in": last_in, "clock_out": last_out})
 

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -63,8 +63,10 @@
             </button>
           </div>
           <h2 class="text-[#111418] text-[22px] font-bold tracking-[-0.015em] px-4 pb-3 pt-5">Submitted Reports</h2>
-          <div class="flex px-4 py-3">
-            <input id="report-date" type="date" class="form-input" />
+          <div class="flex px-4 py-3 gap-2">
+            <input id="report-start" type="date" class="form-input" />
+            <span class="self-center">to</span>
+            <input id="report-end" type="date" class="form-input" />
           </div>
           <div id="reports" class="px-4"></div>
         </div>

--- a/frontend/src/dashboard_admin.js
+++ b/frontend/src/dashboard_admin.js
@@ -73,7 +73,7 @@ loadUserRole();
 
 async function exportCsv() {
     const data = await apiRequest('/dashboard');
-    let csv = 'Employee Name,Total Hours,Utilization Rate\n';
+    let csv = '\ufeffEmployee Name,Total Hours,Utilization Rate\n';
     Object.keys(data.totals).sort().forEach(name => {
         const hours = data.totals[name];
         const utilization = Math.round((hours / getMonthlyTargetHours()) * 100);

--- a/frontend/src/report.js
+++ b/frontend/src/report.js
@@ -58,13 +58,20 @@ async function submitReport() {
 
 let allReports = [];
 
-function renderReportsForDate() {
+function renderReportsForRange() {
     const container = document.getElementById('reports');
     container.innerHTML = '';
-    const dateStr = document.getElementById('report-date').value;
+    const startStr = document.getElementById('report-start').value;
+    const endStr = document.getElementById('report-end').value;
+    const start = startStr ? new Date(startStr) : null;
+    const end = endStr ? new Date(endStr) : null;
+    if (end) {
+        end.setDate(end.getDate() + 1);
+    }
     if (!Array.isArray(allReports)) return;
     allReports.forEach(r => {
-        if (!dateStr || r.timestamp.startsWith(dateStr)) {
+        const ts = new Date(r.timestamp);
+        if ((!start || ts >= start) && (!end || ts < end)) {
             const div = document.createElement('div');
             const time = formatTime(r.timestamp);
             const name = r.name || '';
@@ -77,7 +84,7 @@ function renderReportsForDate() {
 
 async function loadReports() {
     allReports = await apiRequest('/reports');
-    renderReportsForDate();
+    renderReportsForRange();
 }
 
 document.getElementById('submit-report').addEventListener('click', submitReport);
@@ -97,10 +104,16 @@ document.getElementById('logout').addEventListener('click', async () => {
     location.href = 'login.html';
 });
 
-const dateInput = document.getElementById('report-date');
-if (dateInput) {
-    dateInput.value = new Date().toISOString().slice(0, 10);
-    dateInput.addEventListener('change', renderReportsForDate);
+const startInput = document.getElementById('report-start');
+const endInput = document.getElementById('report-end');
+if (startInput && endInput) {
+    const today = new Date();
+    const weekAgo = new Date();
+    weekAgo.setDate(today.getDate() - 7);
+    startInput.value = weekAgo.toISOString().slice(0, 10);
+    endInput.value = today.toISOString().slice(0, 10);
+    startInput.addEventListener('change', renderReportsForRange);
+    endInput.addEventListener('change', renderReportsForRange);
 }
 
 loadReports();

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -15,9 +15,11 @@ th, td { border: 1px solid #ccc; padding: 4px 8px; }
   height: 70vh;
   overflow-y: auto;
 }
+#reports h1 { font-size: 1.5em; margin-top: 0.5em; font-weight: bold; }
+#reports h2 { font-size: 1.25em; margin-top: 0.5em; font-weight: bold; }
+#reports h3 { font-size: 1.1em; margin-top: 0.5em; font-weight: bold; }
 .modal-content h1 { font-size: 1.5em; margin-top: 0.5em; }
 .modal-content h2 { font-size: 1.25em; margin-top: 0.5em; }
-#reports h1, #reports h2 { margin-top: 0.5em; font-weight: bold; }
 #reports ul, #modal-body ul { list-style: disc; margin-left: 1.5em; }
 #reports ol, #modal-body ol { list-style: decimal; margin-left: 1.5em; }
 .close-button { cursor: pointer; float: right; }


### PR DESCRIPTION
## Summary
- retain clock-in time on page reload
- style report headings consistently
- support date range filters in submitted reports
- default report range to past week
- add BOM to CSV exports for Japanese names

## Testing
- `npm --version`
- `python3 --version`


------
https://chatgpt.com/codex/tasks/task_e_685b8f9d00248324b7b859653e598c7b