### PR TITLE
Add language switch with basic translations

### DIFF
--- a/frontend/attendance.html
+++ b/frontend/attendance.html
@@ -19,6 +19,13 @@
         class="min-h-screen bg-white flex flex-col"
         style="font-family: Inter, 'Noto Sans', sans-serif"
     >
+        <div class="lang-switch">
+            <label class="switch">
+                <input type="checkbox" id="lang-toggle-checkbox" />
+                <span class="slider"></span>
+            </label>
+            <span id="lang-toggle-label" class="ml-1">EN</span>
+        </div>
         <div class="flex flex-col grow">
             <header
                 class="flex items-center justify-between border-b border-[#f0f2f4] px-10 py-3"
@@ -51,25 +58,25 @@
                         <a
                             class="text-[#111418] text-sm font-medium"
                             href="attendance.html"
-                            >Attendance</a
+                            data-i18n="nav_attendance">Attendance</a
                         >
                         <a
                             class="text-[#111418] text-sm font-medium"
                             id="dashboard-link"
                             href="dashboard_user.html"
-                            >Dashboard</a
+                            data-i18n="nav_dashboard">Dashboard</a
                         >
                         <a
                             class="text-[#111418] text-sm font-medium"
                             href="report.html"
-                            >Reports</a
+                            data-i18n="nav_reports">Reports</a
                         >
                     </div>
                     <a
                         id="logout"
                         class="text-[#111418] text-sm font-medium"
                         href="#"
-                        >Logout</a
+                        data-i18n="nav_logout">Logout</a
                     >
                 </div>
             </header>
@@ -79,7 +86,7 @@
                         <p
                             class="text-[#111418] text-[32px] font-bold leading-tight min-w-72"
                         >
-                            Attendance
+                            <span data-i18n="attendance_heading">Attendance</span>
                         </p>
                     </div>
                     <div class="flex justify-center">
@@ -90,13 +97,13 @@
                                 id="clock-in"
                                 class="h-12 px-5 rounded-lg bg-[#197fe5] text-white text-base font-bold min-w-[84px] grow"
                             >
-                                <span class="truncate">Clock In</span>
+                                <span class="truncate" data-i18n="clock_in">Clock In</span>
                             </button>
                             <button
                                 id="clock-out"
                                 class="h-12 px-5 rounded-lg bg-[#f0f2f4] text-[#111418] text-base font-bold min-w-[84px] grow"
                             >
-                                <span class="truncate">Clock Out</span>
+                                <span class="truncate" data-i18n="clock_out">Clock Out</span>
                             </button>
                         </div>
                     </div>
@@ -107,13 +114,13 @@
                     <h2
                         class="text-[#111418] text-[22px] font-bold tracking-[-0.015em] px-4 pb-3 pt-5"
                     >
-                        Monthly Summary
+                        <span data-i18n="monthly_summary">Monthly Summary</span>
                     </h2>
                     <div class="flex flex-wrap gap-4 p-4">
                         <div
                             class="flex flex-col gap-2 min-w-[158px] flex-1 rounded-lg p-6 border border-[#dce0e5]"
                         >
-                            <p class="text-[#111418] text-base font-medium">
+                            <p class="text-[#111418] text-base font-medium" data-i18n="total_working_hours">
                                 Total Working Hours
                             </p>
                             <p
@@ -127,6 +134,7 @@
                 </div>
             </div>
         </div>
+        <script src="src/i18n.js"></script>
         <script src="src/attendance.js"></script>
     </body>
 </html>

--- a/frontend/dashboard_admin.html
+++ b/frontend/dashboard_admin.html
@@ -15,6 +15,13 @@
         <link rel="stylesheet" href="src/style.css" />
     </head>
     <body>
+        <div class="lang-switch">
+            <label class="switch">
+                <input type="checkbox" id="lang-toggle-checkbox" />
+                <span class="slider"></span>
+            </label>
+            <span id="lang-toggle-label" class="ml-1">EN</span>
+        </div>
         <div
             class="relative flex size-full min-h-screen flex-col bg-white group/design-root overflow-x-hidden"
             style="font-family: Inter, 'Noto Sans', sans-serif"
@@ -51,24 +58,24 @@
                             <a
                                 class="text-[#111418] text-sm font-medium"
                                 href="attendance.html"
-                                >Attendance</a
+                                data-i18n="nav_attendance">Attendance</a
                             >
                             <a
                                 class="text-[#111418] text-sm font-medium"
                                 href="dashboard_admin.html"
-                                >Dashboard</a
+                                data-i18n="nav_dashboard">Dashboard</a
                             >
                             <a
                                 class="text-[#111418] text-sm font-medium"
                                 href="report.html"
-                                >Reports</a
+                                data-i18n="nav_reports">Reports</a
                             >
                         </div>
                         <a
                             id="logout"
                             class="text-[#111418] text-sm font-medium"
                             href="#"
-                            >Logout</a
+                            data-i18n="nav_logout">Logout</a
                         >
                     </div>
                 </header>
@@ -81,10 +88,11 @@
                                 <p
                                     class="text-[#111418] tracking-light text-[32px] font-bold leading-tight"
                                 >
-                                    Attendance Overview
+                                    <span data-i18n="admin_overview_title">Attendance Overview</span>
                                 </p>
                                 <p
                                     class="text-[#637588] text-sm font-normal leading-normal"
+                                    data-i18n="admin_overview_desc"
                                 >
                                     Current month's attendance records for all
                                     employees.
@@ -101,17 +109,17 @@
                                             <th
                                                 class="table-column-120 px-4 py-3 text-left text-[#111418] w-[400px] text-sm font-medium leading-normal"
                                             >
-                                                Employee Name
+                                                <span data-i18n="employee_name">Employee Name</span>
                                             </th>
                                             <th
                                                 class="table-column-360 px-4 py-3 text-left text-[#111418] w-[400px] text-sm font-medium leading-normal"
                                             >
-                                                Total Hours
+                                                <span data-i18n="total_hours">Total Hours</span>
                                             </th>
                                             <th
                                                 class="table-column-480 px-4 py-3 text-left text-[#111418] w-[400px] text-sm font-medium leading-normal"
                                             >
-                                                Utilization Rate
+                                                <span data-i18n="utilization_rate">Utilization Rate</span>
                                             </th>
                                         </tr>
                                     </thead>
@@ -141,13 +149,14 @@
                                 id="export-csv"
                                 class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#f0f2f4] text-[#111418] text-sm font-bold leading-normal tracking-[0.015em]"
                             >
-                                <span class="truncate">Export to CSV</span>
+                                <span class="truncate" data-i18n="export_csv">Export to CSV</span>
                             </button>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
+        <script src="src/i18n.js"></script>
         <script src="src/dashboard_admin.js"></script>
     </body>
 </html>

--- a/frontend/dashboard_user.html
+++ b/frontend/dashboard_user.html
@@ -18,6 +18,13 @@
         class="relative flex min-h-screen flex-col bg-neutral-50 overflow-x-hidden"
         style="font-family: Inter, 'Noto Sans', sans-serif"
     >
+        <div class="lang-switch">
+            <label class="switch">
+                <input type="checkbox" id="lang-toggle-checkbox" />
+                <span class="slider"></span>
+            </label>
+            <span id="lang-toggle-label" class="ml-1">EN</span>
+        </div>
         <div class="layout-container flex h-full grow flex-col">
             <header
                 class="flex items-center justify-between border-b border-[#f0f2f4] px-10 py-3"
@@ -50,25 +57,25 @@
                         <a
                             class="text-[#111418] text-sm font-medium"
                             href="attendance.html"
-                            >Attendance</a
+                            data-i18n="nav_attendance">Attendance</a
                         >
                         <a
                             class="text-[#111418] text-sm font-medium"
                             id="dashboard-link"
                             href="dashboard_user.html"
-                            >Dashboard</a
+                            data-i18n="nav_dashboard">Dashboard</a
                         >
                         <a
                             class="text-[#111418] text-sm font-medium"
                             href="report.html"
-                            >Reports</a
+                            data-i18n="nav_reports">Reports</a
                         >
                     </div>
                     <a
                         id="logout"
                         class="text-[#111418] text-sm font-medium"
                         href="#"
-                        >Logout</a
+                        data-i18n="nav_logout">Logout</a
                     >
                 </div>
             </header>
@@ -81,7 +88,7 @@
                             <p
                                 class="text-[#141414] tracking-light text-[32px] font-bold leading-tight"
                             >
-                                Dashboard
+                                <span data-i18n="nav_dashboard">Dashboard</span>
                             </p>
                             <p
                                 class="text-neutral-500 text-sm font-normal leading-normal"
@@ -97,7 +104,7 @@
                             <p
                                 class="text-[#141414] text-base font-medium leading-normal"
                             >
-                                Total Working Hours
+                                <span data-i18n="total_working_hours">Total Working Hours</span>
                             </p>
                             <p
                                 id="total-hours-value"
@@ -112,7 +119,7 @@
                             <p
                                 class="text-[#141414] text-base font-medium leading-normal"
                             >
-                                Utilization Rate
+                                <span data-i18n="utilization_rate">Utilization Rate</span>
                             </p>
                             <p
                                 id="utilization-rate-value"
@@ -125,7 +132,7 @@
                     <h2
                         class="text-[#141414] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5"
                     >
-                        Monthly Report
+                        <span data-i18n="monthly_report">Monthly Report</span>
                     </h2>
                     <div class="flex flex-wrap gap-4 px-4 py-6">
                         <div
@@ -134,7 +141,7 @@
                             <p
                                 class="text-[#141414] text-base font-medium leading-normal"
                             >
-                                Monthly Working Hours
+                                <span data-i18n="monthly_working_hours">Monthly Working Hours</span>
                             </p>
                             <p
                                 id="monthly-hours"
@@ -146,7 +153,7 @@
                                 <p
                                     class="text-neutral-500 text-base font-normal leading-normal"
                                 >
-                                    This Month
+                                    <span data-i18n="this_month">This Month</span>
                                 </p>
                                 <p
                                     id="monthly-change"
@@ -171,6 +178,7 @@
                 </div>
             </div>
         </div>
+        <script src="src/i18n.js"></script>
         <script src="src/dashboard_user.js"></script>
     </body>
 </html>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -8,13 +8,20 @@
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 </head>
 <body class="bg-white min-h-screen flex flex-col" style='font-family: Inter, "Noto Sans", sans-serif;'>
+    <div class="lang-switch">
+        <label class="switch">
+            <input type="checkbox" id="lang-toggle-checkbox" />
+            <span class="slider"></span>
+        </label>
+        <span id="lang-toggle-label" class="ml-1">EN</span>
+    </div>
     <div class="flex flex-1 justify-center py-5 px-4">
         <div class="w-full max-w-[512px] flex flex-col py-5">
-            <h2 class="text-[#121416] text-[28px] font-bold leading-tight text-center pb-3 pt-5">Welcome to WorkFlow</h2>
-            <p class="text-[#121416] text-base text-center pb-3 pt-1">Sign in with your company account to continue</p>
+            <h2 class="text-[#121416] text-[28px] font-bold leading-tight text-center pb-3 pt-5" data-i18n="login_welcome">Welcome to WorkFlow</h2>
+            <p class="text-[#121416] text-base text-center pb-3 pt-1" data-i18n="login_prompt">Sign in with your company account to continue</p>
             <div class="flex justify-center py-3">
                 <button class="flex items-center justify-center h-10 px-4 rounded-xl bg-[#b2cbe5] text-[#121416] text-sm font-bold min-w-[84px] max-w-[480px]">
-                    <span class="truncate">Sign in with Microsoft</span>
+                    <span class="truncate" data-i18n="login_ms_btn">Sign in with Microsoft</span>
                 </button>
             </div>
             <form id="login-form" class="flex flex-col items-stretch">
@@ -30,13 +37,14 @@
                 </div>
                 <div class="flex justify-center py-3">
                     <button type="submit" class="flex items-center justify-center h-10 px-4 rounded-xl bg-[#b2cbe5] text-[#121416] text-sm font-bold min-w-[84px] max-w-[480px]">
-                        <span class="truncate">Sign In</span>
+                    <span class="truncate" data-i18n="login_signin_btn">Sign In</span>
                     </button>
                 </div>
             </form>
-            <p class="text-[#6a7581] text-sm text-center underline pb-3 pt-1"><a href="register.html">Don't have an account? Sign up</a></p>
+            <p class="text-[#6a7581] text-sm text-center underline pb-3 pt-1"><a href="register.html" data-i18n="login_signup_link">Don't have an account? Sign up</a></p>
         </div>
     </div>
+    <script src="src/i18n.js"></script>
     <script src="src/login.js"></script>
 </body>
 </html>

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -8,9 +8,16 @@
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 </head>
 <body class="bg-white min-h-screen flex flex-col" style='font-family: Inter, "Noto Sans", sans-serif;'>
+    <div class="lang-switch">
+        <label class="switch">
+            <input type="checkbox" id="lang-toggle-checkbox" />
+            <span class="slider"></span>
+        </label>
+        <span id="lang-toggle-label" class="ml-1">EN</span>
+    </div>
     <div class="flex flex-1 justify-center py-5 px-4">
         <div class="w-full max-w-[512px] flex flex-col py-5">
-            <h2 class="text-[#111418] text-[28px] font-bold leading-tight text-center pb-3 pt-5">Welcome to WorkWise</h2>
+            <h2 class="text-[#111418] text-[28px] font-bold leading-tight text-center pb-3 pt-5" data-i18n="register_welcome">Welcome to WorkWise</h2>
             <form id="register-form" class="flex flex-col items-stretch">
                 <div class="flex flex-wrap gap-4 py-3">
                     <label class="flex flex-col flex-1 min-w-40">
@@ -42,13 +49,14 @@
                 </div>
                 <div class="flex justify-center py-3">
                     <button type="submit" class="flex items-center justify-center h-10 px-4 rounded-xl bg-[#197fe5] text-white text-sm font-bold min-w-[84px] max-w-[480px]">
-                        <span class="truncate">Create</span>
+                        <span class="truncate" data-i18n="register_create_btn">Create</span>
                     </button>
                 </div>
             </form>
-            <p class="text-[#6a7581] text-sm text-center underline pb-3 pt-1"><a href="login.html">Back to Login</a></p>
+            <p class="text-[#6a7581] text-sm text-center underline pb-3 pt-1"><a href="login.html" data-i18n="register_back_login">Back to Login</a></p>
         </div>
     </div>
+    <script src="src/i18n.js"></script>
     <script src="src/register.js"></script>
 </body>
 </html>

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -19,6 +19,13 @@
         class="min-h-screen flex flex-col bg-white"
         style="font-family: Inter, 'Noto Sans', sans-serif; margin: 0"
     >
+        <div class="lang-switch">
+            <label class="switch">
+                <input type="checkbox" id="lang-toggle-checkbox" />
+                <span class="slider"></span>
+            </label>
+            <span id="lang-toggle-label" class="ml-1">EN</span>
+        </div>
         <div class="flex flex-col grow">
             <header
                 class="flex items-center justify-between border-b border-[#f0f2f4] px-10 py-3"
@@ -51,25 +58,25 @@
                         <a
                             class="text-[#111418] text-sm font-medium"
                             href="attendance.html"
-                            >Attendance</a
+                            data-i18n="nav_attendance">Attendance</a
                         >
                         <a
                             class="text-[#111418] text-sm font-medium"
                             id="dashboard-link"
                             href="dashboard_user.html"
-                            >Dashboard</a
+                            data-i18n="nav_dashboard">Dashboard</a
                         >
                         <a
                             class="text-[#111418] text-sm font-medium"
                             href="report.html"
-                            >Reports</a
+                            data-i18n="nav_reports">Reports</a
                         >
                     </div>
                     <a
                         id="logout"
                         class="text-[#111418] text-sm font-medium"
                         href="#"
-                        >Logout</a
+                        data-i18n="nav_logout">Logout</a
                     >
                 </div>
             </header>
@@ -79,10 +86,10 @@
                         <p
                             class="text-[#111418] text-[32px] font-bold leading-tight min-w-72"
                         >
-                            Daily Report Submission
+                            <span data-i18n="report_heading">Daily Report Submission</span>
                         </p>
                     </div>
-                    <p class="text-[#111418] text-base pb-3 pt-1 px-4">
+                    <p class="text-[#111418] text-base pb-3 pt-1 px-4" data-i18n="report_prompt">
                         Please submit your daily report below. Ensure you have
                         clocked in for the day before submitting.
                     </p>
@@ -101,7 +108,7 @@
                             id="preview"
                             class="flex min-w-[84px] max-w-[480px] items-center justify-center h-10 px-4 rounded-lg bg-[#f0f2f4] text-[#111418] text-sm font-bold"
                         >
-                            <span class="truncate">Preview</span>
+                            <span class="truncate" data-i18n="preview_btn">Preview</span>
                         </button>
                     </div>
                     <div class="flex px-4 py-3 justify-start">
@@ -110,13 +117,13 @@
                             class="flex min-w-[84px] max-w-[480px] items-center justify-center h-10 px-4 rounded-lg bg-[#197fe5] text-white text-sm font-bold"
                             disabled
                         >
-                            <span class="truncate">Submit Report</span>
+                            <span class="truncate" data-i18n="submit_report_btn">Submit Report</span>
                         </button>
                     </div>
                     <h2
                         class="text-[#111418] text-[22px] font-bold tracking-[-0.015em] px-4 pb-3 pt-5"
                     >
-                        Submitted Reports
+                        <span data-i18n="submitted_reports">Submitted Reports</span>
                     </h2>
                     <div class="flex px-4 py-3 gap-2">
                         <input
@@ -124,7 +131,7 @@
                             type="date"
                             class="form-input"
                         />
-                        <span class="self-center">to</span>
+                        <span class="self-center" data-i18n="date_to">to</span>
                         <input id="report-end" type="date" class="form-input" />
                     </div>
                     <div id="reports" class="px-4"></div>
@@ -137,6 +144,7 @@
                 <div id="modal-body"></div>
             </div>
         </div>
+        <script src="src/i18n.js"></script>
         <script src="src/report.js"></script>
     </body>
 </html>

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -1,0 +1,118 @@
+const translations = {
+  en: {
+    login_welcome: "Welcome to WorkFlow",
+    login_prompt: "Sign in with your company account to continue",
+    login_ms_btn: "Sign in with Microsoft",
+    login_signin_btn: "Sign In",
+    login_signup_link: "Don't have an account? Sign up",
+
+    register_welcome: "Welcome to WorkWise",
+    register_create_btn: "Create",
+    register_back_login: "Back to Login",
+
+    nav_attendance: "Attendance",
+    nav_dashboard: "Dashboard",
+    nav_reports: "Reports",
+    nav_logout: "Logout",
+
+    attendance_heading: "Attendance",
+    clock_in: "Clock In",
+    clock_out: "Clock Out",
+    monthly_summary: "Monthly Summary",
+    monthly_report: "Monthly Report",
+    total_working_hours: "Total Working Hours",
+    utilization_rate: "Utilization Rate",
+    monthly_working_hours: "Monthly Working Hours",
+    this_month: "This Month",
+
+    report_heading: "Daily Report Submission",
+    report_prompt: "Please submit your daily report below. Ensure you have clocked in for the day before submitting.",
+    preview_btn: "Preview",
+    submit_report_btn: "Submit Report",
+    submitted_reports: "Submitted Reports",
+    date_to: "to",
+
+    admin_overview_title: "Attendance Overview",
+    admin_overview_desc: "Current month's attendance records for all employees.",
+    employee_name: "Employee Name",
+    total_hours: "Total Hours",
+    export_csv: "Export to CSV"
+  },
+  ja: {
+    login_welcome: "WorkFlow\u3078\u3088\u3046\u3053\u305d",
+    login_prompt: "\u7d9a\u884c\u3059\u308b\u306b\u306f\u4f1a\u793e\u30a2\u30ab\u30a6\u30f3\u30c8\u3067\u30b5\u30a4\u30f3\u30a4\u30f3\u3057\u3066\u304f\u3060\u3055\u3044",
+    login_ms_btn: "Microsoft\u3067\u30b5\u30a4\u30f3\u30a4\u30f3",
+    login_signin_btn: "\u30b5\u30a4\u30f3\u30a4\u30f3",
+    login_signup_link: "\u30a2\u30ab\u30a6\u30f3\u30c8\u3092\u304a\u6301\u3061\u3067\u306f\u306a\u3044\u3067\u3059\u304b? \u767b\u9332\u3059\u308b",
+
+    register_welcome: "WorkWise\u3078\u3088\u3046\u3053\u305d",
+    register_create_btn: "\u4f5c\u6210",
+    register_back_login: "\u30ed\u30b0\u30a4\u30f3\u306b\u623b\u308b",
+
+    nav_attendance: "\u52e4\u6020",
+    nav_dashboard: "\u30c0\u30c3\u30b7\u30e5\u30dc\u30fc\u30c9",
+    nav_reports: "\u30ec\u30dd\u30fc\u30c8",
+    nav_logout: "\u30ed\u30b0\u30a2\u30a6\u30c8",
+
+    attendance_heading: "\u52e4\u6020",
+    clock_in: "\u51fa\u52e4",
+    clock_out: "\u9000\u52e4",
+    monthly_summary: "\u6708\u6b21\u30b5\u30de\u30ea\u30fc",
+    monthly_report: "\u6708\u6b21\u30ec\u30dd\u30fc\u30c8",
+    total_working_hours: "\u7dcf\u52e4\u52d9\u6642\u9593",
+    utilization_rate: "\u52e4\u52d9\u7387",
+    monthly_working_hours: "\u6708\u9593\u52e4\u52d9\u6642\u9593",
+    this_month: "\u4eca\u6708",
+
+    report_heading: "\u65e5\u5831\u306e\u63d0\u51fa",
+    report_prompt: "\u4ee5\u4e0b\u306b\u65e5\u5831\u3092\u5165\u529b\u3057\u3066\u304f\u3060\u3055\u3044\u3002\u63d0\u51fa\u524d\u306b\u51fa\u52e4\u3057\u3066\u3044\u308b\u304b\u78ba\u8a8d\u3057\u3066\u304f\u3060\u3055\u3044\u3002",
+    preview_btn: "\u30d7\u30ec\u30d3\u30e5\u30fc",
+    submit_report_btn: "\u9001\u4fe1",
+    submitted_reports: "\u63d0\u51fa\u6e08\u307f\u30ec\u30dd\u30fc\u30c8",
+    date_to: "\u304b\u3089",
+
+    admin_overview_title: "\u52e4\u6020\u6982\u8981",
+    admin_overview_desc: "\u4eca\u6708\u306e\u5168\u5de5\u54e1\u306e\u52e4\u6020\u8a18\u9332\u3067\u3059\u3002",
+    employee_name: "\u5f93\u696d\u54e1\u540d",
+    total_hours: "\u5408\u8a08\u6642\u9593",
+    export_csv: "CSV\u51fa\u529b"
+  }
+};
+
+function applyTranslations() {
+  const lang = localStorage.getItem('lang') || 'en';
+  document.documentElement.lang = lang;
+  const checkbox = document.getElementById('lang-toggle-checkbox');
+  const label = document.getElementById('lang-toggle-label');
+  if (checkbox) {
+    checkbox.checked = lang === 'ja';
+  }
+  if (label) {
+    label.textContent = lang === 'ja' ? 'JA' : 'EN';
+  }
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.getAttribute('data-i18n');
+    const text = translations[lang][key];
+    if (!text) return;
+    if (el.placeholder !== undefined && el.tagName !== 'SELECT') {
+      el.placeholder = text;
+    } else {
+      el.textContent = text;
+    }
+  });
+}
+
+function initLangSwitch() {
+  const checkbox = document.getElementById('lang-toggle-checkbox');
+  if (checkbox) {
+    checkbox.addEventListener('change', () => {
+      const lang = checkbox.checked ? 'ja' : 'en';
+      localStorage.setItem('lang', lang);
+      applyTranslations();
+    });
+  }
+  applyTranslations();
+}
+
+document.addEventListener('DOMContentLoaded', initLangSwitch);
+

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -23,3 +23,52 @@ th, td { border: 1px solid #ccc; padding: 4px 8px; }
 #reports ul, #modal-body ul { list-style: disc; margin-left: 1.5em; }
 #reports ol, #modal-body ol { list-style: decimal; margin-left: 1.5em; }
 .close-button { cursor: pointer; float: right; }
+
+.lang-switch {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  z-index: 1000;
+  font-size: 12px;
+}
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 34px;
+  height: 18px;
+}
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: 0.4s;
+  border-radius: 34px;
+}
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 14px;
+  width: 14px;
+  left: 2px;
+  bottom: 2px;
+  background-color: white;
+  transition: 0.4s;
+  border-radius: 50%;
+}
+input:checked + .slider {
+  background-color: #2196F3;
+}
+input:checked + .slider:before {
+  transform: translateX(16px);
+}


### PR DESCRIPTION
## Summary
- implement `i18n.js` to manage English and Japanese text
- style toggle switch and display it on every page
- mark key text with `data-i18n` for translation
- load translations through new script on each page

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_685cc8d74ed08324ae1eb285605f23f5