### PR TITLE
Fix language toggle UI

### DIFF
--- a/frontend/attendance.html
+++ b/frontend/attendance.html
@@ -24,7 +24,7 @@
                 <input type="checkbox" id="lang-toggle-checkbox" />
                 <span class="slider"></span>
             </label>
-            <span id="lang-toggle-label" class="ml-1">JA</span>
+            <span id="lang-toggle-label" class="ml-1">EN</span>
         </div>
         <div class="flex flex-col grow">
             <header

--- a/frontend/dashboard_admin.html
+++ b/frontend/dashboard_admin.html
@@ -20,7 +20,7 @@
                 <input type="checkbox" id="lang-toggle-checkbox" />
                 <span class="slider"></span>
             </label>
-            <span id="lang-toggle-label" class="ml-1">JA</span>
+            <span id="lang-toggle-label" class="ml-1">EN</span>
         </div>
         <div
             class="relative flex size-full min-h-screen flex-col bg-white group/design-root overflow-x-hidden"

--- a/frontend/dashboard_user.html
+++ b/frontend/dashboard_user.html
@@ -23,7 +23,7 @@
                 <input type="checkbox" id="lang-toggle-checkbox" />
                 <span class="slider"></span>
             </label>
-            <span id="lang-toggle-label" class="ml-1">JA</span>
+            <span id="lang-toggle-label" class="ml-1">EN</span>
         </div>
         <div class="layout-container flex h-full grow flex-col">
             <header

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -14,7 +14,7 @@
             <input type="checkbox" id="lang-toggle-checkbox" />
             <span class="slider"></span>
         </label>
-        <span id="lang-toggle-label" class="ml-1">JA</span>
+        <span id="lang-toggle-label" class="ml-1">EN</span>
     </div>
     <div class="flex flex-1 justify-center py-5 px-4">
         <div class="w-full max-w-[512px] flex flex-col py-5">

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -14,7 +14,7 @@
             <input type="checkbox" id="lang-toggle-checkbox" />
             <span class="slider"></span>
         </label>
-        <span id="lang-toggle-label" class="ml-1">JA</span>
+        <span id="lang-toggle-label" class="ml-1">EN</span>
     </div>
     <div class="flex flex-1 justify-center py-5 px-4">
         <div class="w-full max-w-[512px] flex flex-col py-5">

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -24,7 +24,7 @@
                 <input type="checkbox" id="lang-toggle-checkbox" />
                 <span class="slider"></span>
             </label>
-            <span id="lang-toggle-label" class="ml-1">JA</span>
+            <span id="lang-toggle-label" class="ml-1">EN</span>
         </div>
         <div class="flex flex-col grow">
             <header

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -87,10 +87,10 @@ function applyTranslations() {
   const checkbox = document.getElementById('lang-toggle-checkbox');
   const label = document.getElementById('lang-toggle-label');
   if (checkbox) {
-    checkbox.checked = lang === 'ja';
+    checkbox.checked = lang === 'en';
   }
   if (label) {
-    label.textContent = lang === 'ja' ? 'JA' : 'EN';
+    label.textContent = 'EN';
   }
   document.querySelectorAll('[data-i18n]').forEach(el => {
     const key = el.getAttribute('data-i18n');
@@ -108,7 +108,7 @@ function initLangSwitch() {
   const checkbox = document.getElementById('lang-toggle-checkbox');
   if (checkbox) {
     checkbox.addEventListener('change', () => {
-      const lang = checkbox.checked ? 'ja' : 'en';
+      const lang = checkbox.checked ? 'en' : 'ja';
       localStorage.setItem('lang', lang);
       applyTranslations();
     });


### PR DESCRIPTION
## Summary
- display `EN` label regardless of language
- switch checkbox so English is active when checked
- show "EN" next to the toggle in all pages

## Testing
- `npm install`
- `npm run copy-vendor` *(fails: cp vendor/marked.min.js: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685ce2fcea888324b24a44568190fc57