### PR TITLE
Fix Japanese message on report screen

### DIFF
--- a/frontend/src/report.js
+++ b/frontend/src/report.js
@@ -108,7 +108,7 @@ async function checkAttendanceAndToggleReport() {
             const warn = document.createElement("div");
             warn.id = "attendance-warning";
             warn.className = "text-red-600 px-4 pb-2";
-            warn.textContent = "You cannot submit a daily report because you have not clocked in today.";
+            warn.textContent = "本日の出勤が記録されていないため、日報を提出できません。";
             reportText.parentNode.insertBefore(warn, reportText);
         }
     } else {


### PR DESCRIPTION
## Summary
- translate the warning shown when submitting a report without clocking in

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_685ce69ef69483248015a52afbf29b8e