### PR TITLE
Enable language toggle on login and attendance pages

### DIFF
--- a/frontend/attendance.html
+++ b/frontend/attendance.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="ja">
   <head>
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
 
@@ -9,6 +10,13 @@
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
   </head>
   <body>
+    <div class="lang-switch" style="margin-top: 45px; margin-right: 33px">
+      <label class="switch">
+        <input type="checkbox" id="lang-toggle-checkbox" />
+        <span class="slider"></span>
+      </label>
+      <span id="lang-toggle-label" class="ml-1">EN</span>
+    </div>
     <div
       class="relative flex size-full min-h-screen flex-col bg-neutral-50 group/design-root overflow-x-hidden"
       style="--checkbox-tick-svg: url('data:image/svg+xml,%3csvg viewBox=%270 0 16 16%27 fill=%27rgb(250,250,250)%27 xmlns=%27http://www.w3.org/2000/svg%27%3e%3cpath d=%27M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z%27/%3e%3c/svg%3e'); font-family: Inter, &quot;Noto Sans&quot;, sans-serif;"
@@ -32,29 +40,29 @@
             <span id="user-name" class="role-label"></span>
             <span id="user-role" class="role-label"></span>
             <div class="flex items-center gap-9">
-              <a class="text-[#111418] text-sm font-medium" href="attendance.html">Attendance</a>
-              <a class="text-[#111418] text-sm font-medium" id="dashboard-link" href="dashboard_user.html">Dashboard</a>
-              <a class="text-[#111418] text-sm font-medium" href="report.html">Reports</a>
+              <a class="text-[#111418] text-sm font-medium" href="attendance.html" data-i18n="nav_attendance">Attendance</a>
+              <a class="text-[#111418] text-sm font-medium" id="dashboard-link" href="dashboard_user.html" data-i18n="nav_dashboard">Dashboard</a>
+              <a class="text-[#111418] text-sm font-medium" href="report.html" data-i18n="nav_reports">Reports</a>
             </div>
-            <a id="logout" class="text-[#111418] text-sm font-medium" href="#">Logout</a>
+            <a id="logout" class="text-[#111418] text-sm font-medium" href="#" data-i18n="nav_logout">Logout</a>
           </div>
         </header>
         <div class="px-40 flex flex-1 justify-center py-5">
           <div class="layout-content-container flex flex-col max-w-[960px] flex-1">
-            <div class="flex flex-wrap justify-between gap-3 p-4"><p class="text-[#141414] tracking-light text-[32px] font-bold leading-tight min-w-72">Attendance</p></div>
+            <div class="flex flex-wrap justify-between gap-3 p-4"><p class="text-[#141414] tracking-light text-[32px] font-bold leading-tight min-w-72" data-i18n="attendance_heading">Attendance</p></div>
             <div class="flex justify-stretch">
               <div class="flex flex-1 gap-3 flex-wrap px-4 py-3 justify-start">
                 <button
                   id="clock-in"
                   class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-black text-neutral-50 text-sm font-bold leading-normal tracking-[0.015em]"
                 >
-                  <span class="truncate">Clock In</span>
+                  <span class="truncate" data-i18n="clock_in">Clock In</span>
                 </button>
                 <button
                   id="clock-out"
                   class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-[#ededed] text-[#141414] text-sm font-bold leading-normal tracking-[0.015em]"
                 >
-                  <span class="truncate">Clock Out</span>
+                  <span class="truncate" data-i18n="clock_out">Clock Out</span>
                 </button>
               </div>
             </div>
@@ -147,5 +155,6 @@
       </div>
     </div>
   </body>
+  <script src="src/i18n.js"></script>
   <script src="src/attendance.js"></script>
 </html>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
     <meta charset="UTF-8">
     <title>Login</title>
@@ -9,13 +9,20 @@
     <script src="https://alcdn.msauth.net/browser/2.38.0/js/msal-browser.min.js"></script>
 </head>
 <body class="bg-white min-h-screen flex flex-col" style='font-family: Inter, "Noto Sans", sans-serif;'>
+    <div class="lang-switch" style="margin-top: 15px; margin-right: 33px">
+        <label class="switch">
+            <input type="checkbox" id="lang-toggle-checkbox" />
+            <span class="slider"></span>
+        </label>
+        <span id="lang-toggle-label" class="ml-1">EN</span>
+    </div>
     <div class="flex flex-1 justify-center py-5 px-4">
         <div class="w-full max-w-[512px] flex flex-col py-5">
-            <h2 class="text-[#121416] text-[28px] font-bold leading-tight text-center pb-3 pt-5">Welcome to WorkFlow</h2>
-            <p class="text-[#121416] text-base text-center pb-3 pt-1">Sign in with your company account to continue</p>
+            <h2 class="text-[#121416] text-[28px] font-bold leading-tight text-center pb-3 pt-5" data-i18n="login_welcome">Welcome to WorkFlow</h2>
+            <p class="text-[#121416] text-base text-center pb-3 pt-1" data-i18n="login_prompt">Sign in with your company account to continue</p>
             <div class="flex justify-center py-3">
                 <button class="flex items-center justify-center h-10 px-4 rounded-xl bg-[#b2cbe5] text-[#121416] text-sm font-bold min-w-[84px] max-w-[480px]">
-                    <span class="truncate">Sign in with Microsoft</span>
+                    <span class="truncate" data-i18n="login_ms_btn">Sign in with Microsoft</span>
                 </button>
             </div>
             <form id="login-form" class="flex flex-col items-stretch">
@@ -31,13 +38,14 @@
                 </div>
                 <div class="flex justify-center py-3">
                     <button type="submit" class="flex items-center justify-center h-10 px-4 rounded-xl bg-[#b2cbe5] text-[#121416] text-sm font-bold min-w-[84px] max-w-[480px]">
-                        <span class="truncate">Sign In</span>
+                        <span class="truncate" data-i18n="login_signin_btn">Sign In</span>
                     </button>
                 </div>
             </form>
-            <p class="text-[#6a7581] text-sm text-center underline pb-3 pt-1"><a href="register.html">Don't have an account? Sign up</a></p>
+            <p class="text-[#6a7581] text-sm text-center underline pb-3 pt-1"><a href="register.html" data-i18n="login_signup_link">Don't have an account? Sign up</a></p>
         </div>
     </div>
+    <script src="src/i18n.js"></script>
     <script type="module" src="src/login.js"></script>
 </body>
 </html>

--- a/frontend/src/login.js
+++ b/frontend/src/login.js
@@ -47,7 +47,9 @@ if (msBtn) {
 }
 
 // ...既存のフォームログイン処理...
-async function apiRequest(path, options) {
+async function apiRequest(path, options = {}) {
+    options.headers = options.headers || {};
+    options.headers['Accept-Language'] = localStorage.getItem('lang') || 'ja';
     const res = await fetch(path, options);
     return res.json();
 }


### PR DESCRIPTION
## Summary
- localize login page with lang switch and i18n text
- localize attendance page with lang switch and i18n text
- send current language to backend during login

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685dee1278408324be8e7a4f41f6d73b