### PR TITLE
Fix Japanese defaults and layout

### DIFF
--- a/frontend/attendance.html
+++ b/frontend/attendance.html
@@ -1,7 +1,13 @@
 <!DOCTYPE html>
 <html lang="ja">
   <head>
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin />
+    <link
+      rel="stylesheet"
+      as="style"
+      onload="this.rel='stylesheet'"
+      href="https://fonts.googleapis.com/css2?display=swap&family=Inter:wght@400;500;700;900&family=Noto+Sans:wght@400;500;700;900"
+    />
     <link rel="stylesheet" href="src/style.css" />
 
     <title>Attendance</title>
@@ -9,7 +15,7 @@
 
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
   </head>
-  <body>
+  <body class="relative flex min-h-screen flex-col bg-neutral-50 overflow-x-hidden" style="font-family: Inter, 'Noto Sans', sans-serif">
     <div class="lang-switch" style="margin-top: 45px; margin-right: 33px">
       <label class="switch">
         <input type="checkbox" id="lang-toggle-checkbox" />
@@ -19,7 +25,7 @@
     </div>
     <div
       class="relative flex size-full min-h-screen flex-col bg-neutral-50 group/design-root overflow-x-hidden"
-      style="--checkbox-tick-svg: url('data:image/svg+xml,%3csvg viewBox=%270 0 16 16%27 fill=%27rgb(250,250,250)%27 xmlns=%27http://www.w3.org/2000/svg%27%3e%3cpath d=%27M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z%27/%3e%3c/svg%3e'); font-family: Inter, &quot;Noto Sans&quot;, sans-serif;"
+      style="--checkbox-tick-svg: url('data:image/svg+xml,%3csvg viewBox=%270 0 16 16%27 fill=%27rgb(250,250,250)%27 xmlns=%27http://www.w3.org/2000/svg%27%3e%3cpath d=%27M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z%27/%3e%3c/svg%3e');"
     >
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between border-b border-[#f0f2f4] px-10 py-3">
@@ -68,15 +74,15 @@
             </div>
             <div class="flex flex-wrap gap-4 p-4">
               <div class="flex min-w-[158px] flex-1 flex-col gap-2 rounded-xl p-6 border border-[#dbdbdb]">
-                <p class="text-[#141414] text-base font-medium leading-normal">Clock In Time</p>
+                <p class="text-[#141414] text-base font-medium leading-normal" data-i18n="clock_in_time">Clock In Time</p>
                 <p id="attendance-msg" class="text-[#141414] tracking-light text-2xl font-bold leading-tight">9:00 AM</p>
               </div>
               <div class="flex min-w-[158px] flex-1 flex-col gap-2 rounded-xl p-6 border border-[#dbdbdb]">
-                <p class="text-[#141414] text-base font-medium leading-normal">Clock Out Time</p>
+                <p class="text-[#141414] text-base font-medium leading-normal" data-i18n="clock_out_time">Clock Out Time</p>
                 <p id="monthly-hours" class="text-[#141414] tracking-light text-2xl font-bold leading-tight">5:00 PM</p>
               </div>
               <div class="flex min-w-[158px] flex-1 flex-col gap-2 rounded-xl p-6 border border-[#dbdbdb]">
-                <p class="text-[#141414] text-base font-medium leading-normal">Hours Worked (Month)</p>
+                <p class="text-[#141414] text-base font-medium leading-normal" data-i18n="hours_worked_month">Hours Worked (Month)</p>
                 <p id="monthly-summary" class="text-[#141414] tracking-light text-2xl font-bold leading-tight">0h 0m</p>
               </div>
             </div>
@@ -85,17 +91,17 @@
                 <button
                   class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-black text-neutral-50 text-sm font-bold leading-normal tracking-[0.015em]"
                 >
-                  <span class="truncate">Add Task</span>
+                  <span class="truncate" data-i18n="add_task">Add Task</span>
                 </button>
                 <button
                   class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-[#ededed] text-[#141414] text-sm font-bold leading-normal tracking-[0.015em]"
                 >
-                  <span class="truncate">Edit</span>
+                  <span class="truncate" data-i18n="edit">Edit</span>
                 </button>
                 <button
                   class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-[#ededed] text-[#141414] text-sm font-bold leading-normal tracking-[0.015em]"
                 >
-                  <span class="truncate">Delete</span>
+                  <span class="truncate" data-i18n="delete">Delete</span>
                 </button>
               </div>
             </div>
@@ -104,8 +110,8 @@
                 <table class="flex-1">
                   <thead>
                     <tr class="bg-neutral-50">
-                      <th class="table-920539b3-9f45-44c8-b0b4-e2c43ca80026-column-56 px-4 py-3 text-left text-[#141414] w-[120px] text-sm font-medium leading-normal">Status</th>
-                      <th class="table-920539b3-9f45-44c8-b0b4-e2c43ca80026-column-176 px-4 py-3 text-left text-[#141414] w-[400px] text-sm font-medium leading-normal">Task</th>
+                      <th class="table-920539b3-9f45-44c8-b0b4-e2c43ca80026-column-56 px-4 py-3 text-left text-[#141414] w-[120px] text-sm font-medium leading-normal" data-i18n="status">Status</th>
+                      <th class="table-920539b3-9f45-44c8-b0b4-e2c43ca80026-column-176 px-4 py-3 text-left text-[#141414] w-[400px] text-sm font-medium leading-normal" data-i18n="task">Task</th>
                     </tr>
                   </thead>
                   <tbody>

--- a/frontend/src/dashboard_user.js
+++ b/frontend/src/dashboard_user.js
@@ -68,14 +68,14 @@ async function loadDashboard() {
     let header = "<tr>";
     if (currentRole === "admin") {
         header +=
-            '<th class="px-4 py-3 text-left text-[#111418] font-medium">Employee Name</th>';
+            '<th class="px-4 py-3 text-left text-[#111418] font-medium" data-i18n="employee_name">Employee Name</th>';
     }
     header +=
-        '<th class="px-4 py-3 text-left text-[#111418] font-medium">Clock In</th>';
+        '<th class="px-4 py-3 text-left text-[#111418] font-medium" data-i18n="clock_in">Clock In</th>';
     header +=
-        '<th class="px-4 py-3 text-left text-[#111418] font-medium">Clock Out</th>';
+        '<th class="px-4 py-3 text-left text-[#111418] font-medium" data-i18n="clock_out">Clock Out</th>';
     header +=
-        '<th class="px-4 py-3 text-left text-[#111418] font-medium">Hours Worked</th>';
+        '<th class="px-4 py-3 text-left text-[#111418] font-medium" data-i18n="hours_worked">Hours Worked</th>';
     if (currentRole === "admin") {
         header +=
             '<th class="px-4 py-3 text-left text-[#111418] font-medium">Monthly Total</th>';
@@ -110,6 +110,9 @@ async function loadDashboard() {
     });
     table.appendChild(tbody);
     container.appendChild(table);
+    if (typeof applyTranslations === 'function') {
+        applyTranslations();
+    }
 
     // calculate metrics
     const totalHours = Object.values(data.totals).reduce((a, b) => a + b, 0);

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -38,7 +38,16 @@ const translations = {
     admin_overview_desc: "Current month's attendance records for all employees.",
     employee_name: "Employee Name",
     total_hours: "Total Hours",
-    export_csv: "Export to CSV"
+    export_csv: "Export to CSV",
+    clock_in_time: "Clock In Time",
+    clock_out_time: "Clock Out Time",
+    hours_worked_month: "Hours Worked (Month)",
+    add_task: "Add Task",
+    edit: "Edit",
+    delete: "Delete",
+    status: "Status",
+    task: "Task",
+    hours_worked: "Hours Worked"
   },
   ja: {
     login_welcome: "WorkFlow\u3078\u3088\u3046\u3053\u305d",
@@ -79,7 +88,16 @@ const translations = {
     admin_overview_desc: "\u4eca\u6708\u306e\u5168\u5de5\u54e1\u306e\u52e4\u6020\u8a18\u9332\u3067\u3059\u3002",
     employee_name: "\u5f93\u696d\u54e1\u540d",
     total_hours: "\u5408\u8a08\u6642\u9593",
-    export_csv: "CSV\u51fa\u529b"
+    export_csv: "CSV\u51fa\u529b",
+    clock_in_time: "\u51fa\u52e4\u6642\u9593",
+    clock_out_time: "\u9000\u52e4\u6642\u9593",
+    hours_worked_month: "\u6708\u9593\u52e4\u52d9\u6642\u9593",
+    add_task: "\u30bf\u30b9\u30af\u8ffd\u52a0",
+    edit: "\u7de8\u96c6",
+    delete: "\u524a\u9664",
+    status: "\u72b6\u614b",
+    task: "\u30bf\u30b9\u30af",
+    hours_worked: "\u52e4\u52d9\u6642\u9593"
   }
 };
 


### PR DESCRIPTION
## Summary
- add missing font sheet and set font on attendance page
- localize attendance page labels and buttons using `data-i18n`
- add translations for new strings
- translate dashboard table headers and refresh translations when the table loads

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685dfc8ba4b883248d609e484a9996fb